### PR TITLE
Changed position in firewall rule to Required instead of Optional.

### DIFF
--- a/upcloud/resource_upcloud_firewall_rule.go
+++ b/upcloud/resource_upcloud_firewall_rule.go
@@ -36,7 +36,7 @@ func resourceUpCloudFirewallRule() *schema.Resource {
 			},
 			"position": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"family": {


### PR DESCRIPTION
As mentioned in #32, the `position` argument in firewall rules is required, it is though, in the schema, set to optional.
This PR changes it to Required.