### PR TITLE
Fix for tags.

### DIFF
--- a/upcloud/resource_upcloud_tag.go
+++ b/upcloud/resource_upcloud_tag.go
@@ -28,14 +28,10 @@ func resourceUpCloudTag() *schema.Resource {
 				ForceNew: true,
 			},
 			"servers": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: map[string]*schema.Schema{
-					"server": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     schema.TypeString,
-					},
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
 				},
 			},
 		},
@@ -58,8 +54,12 @@ func resourceUpCloudTagCreate(d *schema.ResourceData, meta interface{}) error {
 		createTagRequest.Description = description.(string)
 	}
 	if servers, ok := d.GetOk("servers"); ok {
-		servers := servers.(map[string]interface{})
-		createTagRequest.Servers = servers["server"].([]string)
+		servers := servers.([]interface{})
+		serversList := make([]string, len(servers))
+		for i := range serversList {
+			serversList[i] = servers[i].(string)
+		}
+		createTagRequest.Servers = serversList
 	}
 
 	tag, err := client.CreateTag(createTagRequest)


### PR DESCRIPTION
Due to the definition of `Servers` in the `Upcloud.Tag` struct in `upcloud-go-api` the API expects a `Servers` parameter with a string list. This is not totally compatible with the API documentation which expects a map with a key named `server` and a value which consist of a `[]string` of IDs.  
This PR makes the terraform API use a list directly on the `servers` key to match the `upcloud-go-api` structure.

To define a set of tags the following is sufficient with this PR:

```hcl
resource "upcloud_tag" "My-tag" {
  name        = "TagName"
  description = "TagDescription"
  servers     = [
     "server-id-1",
     "server-id-2"
  ]
}
```

This should fix #31, although it does not match the http API docs.