### PR TITLE
Bugfix storage backup rule on server creation

### DIFF
--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -12,6 +12,8 @@ resource "upcloud_server" "test" {
   #cpu = "2"
   #mem = "1024"
 
+  ipv6 = false
+
   # Login details
   login {
     user = "tf"
@@ -25,29 +27,34 @@ resource "upcloud_server" "test" {
   }
 
   storage_devices = [
-    {
+  {
       # You can use both storage template names and UUIDs
       size    = 50
       action  = "clone"
+      tier    = "maxiops"
       storage = "Ubuntu Server 16.04 LTS (Xenial Xerus)"
+      # storage = "01000000-0000-4000-8000-000020040100"
 
       #storage = "01ed68b5-ec65-44ec-8e98-0a9ddc187195"
-    },
-    {
-      # Debian GNU/Linux 6.0.1 (Squeeze) (netinst)
-      # Just to show you can attach different kinds of
-      # resources to the instance
-      action = "attach"
 
-      storage = "01000000-0000-4000-8000-000020010301"
-      type    = "cdrom"
-    },
-    {
-      # Additional 25 GB disk
-      action = "create"
-      size   = 25
-      tier   = "maxiops"
-    },
+      backup_rule = {
+        interval = "daily"
+        time = "0100"
+        retention = 8
+      }
+  },
+  {
+      # You can use both storage template names and UUIDs
+      size    = 30
+      action  = "create"
+      tier    = "maxiops"
+
+      backup_rule = {
+        interval = "mon"
+        time = "0000"
+        retention = 7
+      }
+  },
   ]
 }
 

--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -12,8 +12,6 @@ resource "upcloud_server" "test" {
   #cpu = "2"
   #mem = "1024"
 
-  ipv6 = false
-
   # Login details
   login {
     user = "tf"
@@ -32,10 +30,7 @@ resource "upcloud_server" "test" {
       size    = 50
       action  = "clone"
       tier    = "maxiops"
-      storage = "Ubuntu Server 16.04 LTS (Xenial Xerus)"
-      # storage = "01000000-0000-4000-8000-000020040100"
-
-      #storage = "01ed68b5-ec65-44ec-8e98-0a9ddc187195"
+      storage = "01000000-0000-4000-8000-000020040100"
 
       backup_rule = {
         interval = "daily"

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -640,36 +640,6 @@ func buildStorage(storageDevice map[string]interface{}, i int, meta interface{},
 
 	log.Printf("[DEBUG] Disk: %v", osDisk)
 
-	/*
-		if backupRule := storageDevice["backup_rule"].(map[string]interface{}); backupRule != nil && len(backupRule) != 0 {
-			log.Printf("[DEBUG] Backup rule create")
-			retention, err := strconv.Atoi(backupRule["retention"].(string))
-			if err != nil {
-				return nil, err
-			}
-
-			newStorage, err := client.CreateStorage(&request.CreateStorageRequest{
-				Size:  osDisk.Size,
-				Tier:  osDisk.Tier,
-				Title: osDisk.Title,
-				Zone:  zone,
-				BackupRule: &upcloud.BackupRule{
-					Interval:  backupRule["interval"].(string),
-					Retention: retention,
-					Time:      backupRule["time"].(string),
-				},
-			})
-			if err != nil {
-
-				return nil, err
-			}
-
-			osDisk.Action = "attach"
-			osDisk.Storage = newStorage.UUID
-			log.Printf("[DEBUG] newStorage.UUID %s)", newStorage.UUID)
-		}
-	*/
-
 	return &osDisk, nil
 }
 


### PR DESCRIPTION
https://github.com/UpCloudLtd/terraform-provider-upcloud/issues/30

The way the API is set up the storage has to be cloned during the server creation and backup rules added after server creation.

Before this fix the storage was created before the server and thus certain necessary operations were not executed on the main storage which caused the bug of a server without template.