### PR TITLE
Modify tag fix.

### DIFF
--- a/upcloud/resource_upcloud_tag.go
+++ b/upcloud/resource_upcloud_tag.go
@@ -75,15 +75,24 @@ func resourceUpCloudTagCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceUpCloudTagUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*service.Service)
-	r := &request.ModifyTagRequest{}
+	r := &request.ModifyTagRequest{
+		Name: d.Id(),
+	}
 
+	r.Tag.Name = d.Id()
 	if d.HasChange("description") {
 		_, newDescription := d.GetChange("description")
-		r.Description = newDescription.(string)
+		r.Tag.Description = newDescription.(string)
 	}
 	if d.HasChange("servers") {
 		_, newServers := d.GetChange("servers")
-		r.Servers = newServers.([]string)
+
+		servers := newServers.([]interface{})
+		serversList := make([]string, len(servers))
+		for i := range serversList {
+			serversList[i] = servers[i].(string)
+		}
+		r.Tag.Servers = serversList
 	}
 
 	_, err := client.ModifyTag(r)


### PR DESCRIPTION
Updated the resrouceUpCloudTagUpdate function to convert the server map into a list, making it similar to the create function.

While fixing that I encountered further bugs due to invalid `name`.  

The `ModifyTagRequest` structure have a `Tag` and a `Name` property, both of those have to be set, as the `Name` is used in the `RequestURL` for the modify request, while the `Tag.Name` seems to be required for the validation.  
For now, I made the Update function set both of the name properties.  
The same issue (except no outer scope properties) applied to `Servers` and `Description`, so they are now set to the `r.Tag.Servers` and `r.Tag.Description` properties instead.

Tested with create, delete and update, I used the following TF file if someone want to test it more:

```hcl
resource "upcloud_server" "test-server" {
  zone     = "de-fra1"
  hostname = "test1"

  plan = "1xCPU-1GB"
  ipv4 = true

  login {
    user            = "root"
    create_password = false
    keys            = "${var.ssh_keys}"
  }

  storage_devices = [
    {
      tier    = "maxiops"
      size    = 25
      action  = "clone"
      storage = "Ubuntu Server 18.04 (Bionic Beaver)"
    },
  ]
}

resource "upcloud_server" "test-server2" {
  zone     = "de-fra1"
  hostname = "test2"

  plan = "1xCPU-1GB"
  ipv4 = true

  login {
    user            = "root"
    create_password = false
    keys            = "${var.ssh_keys}"
  }

  storage_devices = [
    {
      tier    = "maxiops"
      size    = 25
      action  = "clone"
      storage = "Ubuntu Server 18.04 (Bionic Beaver)"
    },
  ]
}

resource "upcloud_tag" "tag1" {
  depends_on = ["upcloud_server.test-server"]

  name        = "TAG"
  description = "Just some text..."

  servers = [
    #"${upcloud_server.test-server.id}",
    "${upcloud_server.test-server2.id}",
  ]
}
```

Un-comment server 1 when to update!

Should close #31 ! :)