### PR TITLE
Higher timeout for creating servers

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -206,7 +206,7 @@ func resourceUpCloudServerCreate(d *schema.ResourceData, meta interface{}) error
 	server, err = client.WaitForServerState(&request.WaitForServerStateRequest{
 		UUID:         server.UUID,
 		DesiredState: upcloud.ServerStateStarted,
-		Timeout:      time.Minute * 5,
+		Timeout:      time.Minute * 25,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
I've set the timeout higher to accommodate the longer creation times in Chicago and Singapore.
Also, When creating it is probably better to have it take longer than to retry it a few times..