### PR TITLE
Fix falses not being set correctly

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -148,14 +148,14 @@ func resourceUpCloudServer() *schema.Resource {
 							Description: "`true` if source IP should be filtered.",
 							ForceNew:    true,
 							Optional:    true,
-							Computed:    true,
+							Default:     true,
 						},
 						"bootable": {
 							Type:        schema.TypeBool,
 							Description: "`true` if this interface should be used for network booting.",
 							ForceNew:    true,
 							Optional:    true,
-							Computed:    true,
+							Default:     false,
 						},
 					},
 				},
@@ -711,13 +711,8 @@ func buildNetworkOpts(d *schema.ResourceData, meta interface{}) ([]request.Creat
 			Type: d.Get(keyRoot + "type").(string),
 		}
 
-		if v, ok := d.GetOkExists(keyRoot + "source_ip_filtering"); ok {
-			iface.SourceIPFiltering = upcloud.FromBool(v.(bool))
-		}
-
-		if v, ok := d.GetOkExists(keyRoot + "bootable"); ok {
-			iface.Bootable = upcloud.FromBool(v.(bool))
-		}
+		iface.SourceIPFiltering = upcloud.FromBool(d.Get(keyRoot + "source_ip_filtering").(bool))
+		iface.Bootable = upcloud.FromBool(d.Get(keyRoot + "bootable").(bool))
 
 		if v, ok := d.GetOk(keyRoot + "network"); ok {
 			iface.Network = v.(string)

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -147,7 +147,6 @@ func resourceUpCloudServer() *schema.Resource {
 							Type:        schema.TypeBool,
 							Description: "`true` if source IP should be filtered.",
 							ForceNew:    true,
-							Default:     nil,
 							Optional:    true,
 							Computed:    true,
 						},
@@ -712,11 +711,11 @@ func buildNetworkOpts(d *schema.ResourceData, meta interface{}) ([]request.Creat
 			Type: d.Get(keyRoot + "type").(string),
 		}
 
-		if v, ok := d.GetOk(keyRoot + "source_ip_filtering"); ok {
+		if v, ok := d.GetOkExists(keyRoot + "source_ip_filtering"); ok {
 			iface.SourceIPFiltering = upcloud.FromBool(v.(bool))
 		}
 
-		if v, ok := d.GetOk(keyRoot + "bootable"); ok {
+		if v, ok := d.GetOkExists(keyRoot + "bootable"); ok {
 			iface.Bootable = upcloud.FromBool(v.(bool))
 		}
 


### PR DESCRIPTION
getOk requires non-zero value. `False` is the zero value for booleans.

For ref, see #86 

source_ip_filtering