### PR TITLE
Refactor/separate storages from server resource

### DIFF
--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -28,12 +28,9 @@ resource "upcloud_server" "test" {
     password_delivery = "sms"
   }
 
-  storage_devices {
-    # You can use both storage template names and UUIDs
-    size    = 50
-    action  = "clone"
-    tier    = "maxiops"
+  template {
     storage = "Ubuntu Server 16.04 LTS (Xenial Xerus)"
+    size    = 50
 
     backup_rule {
       interval  = "daily"
@@ -43,16 +40,23 @@ resource "upcloud_server" "test" {
   }
 
   storage_devices {
-    size    = 10
-    action  = "create"
-    tier    = "maxiops"
-
-    backup_rule {
-      interval  = "daily"
-      time      = "0100"
-      retention = 8
-    }
+    storage = upcloud_storage.storage.id
+    # address = "virtio"
+    # type    = "disk"
   }
+}
+
+resource "upcloud_storage" "storage" {
+  size  = 10
+  tier  = "maxiops"
+  title = "additional storage"
+  zone  = "fi-hel1"
+
+  # backup_rule {
+  #   interval  = "daily"
+  #   time      = "0100"
+  #   retention = 8
+  # }
 }
 
 resource "upcloud_tag" "My-tag" {

--- a/upcloud/resource_upcloud_firewall_rules_test.go
+++ b/upcloud/resource_upcloud_firewall_rules_test.go
@@ -228,14 +228,12 @@ func testUpcloudFirewallRulesInstanceConfig() string {
 		  hostname = "debian.example.com"
 		  plan     = "1xCPU-2GB"
 
-		  storage_devices {
-			action = "create"
-			size   = 10
-			tier   = "maxiops"
-		  }
+			template {
+      storage = "01000000-0000-4000-8000-000020050100"
+			}
 
 		  network_interface {
-			type = "utility"
+      type = "utility"
 		  }
 
 		}
@@ -268,14 +266,12 @@ func testUpcloudFirewallRulesInstanceConfig_update() string {
 		  hostname = "debian.example.com"
 		  plan     = "1xCPU-2GB"
 
-		  storage_devices {
-			action = "create"
-			size   = 10
-			tier   = "maxiops"
-		  }
+			template {
+      storage = "01000000-0000-4000-8000-000020050100"
+			}
 
 		  network_interface {
-			type = "utility"
+      type = "utility"
 		  }
 
 		}

--- a/upcloud/resource_upcloud_firewall_rules_test.go
+++ b/upcloud/resource_upcloud_firewall_rules_test.go
@@ -228,12 +228,12 @@ func testUpcloudFirewallRulesInstanceConfig() string {
 		  hostname = "debian.example.com"
 		  plan     = "1xCPU-2GB"
 
-			template {
-      storage = "01000000-0000-4000-8000-000020050100"
-			}
+		  template {
+			storage = "01000000-0000-4000-8000-000020050100"
+		  }
 
 		  network_interface {
-      type = "utility"
+			type = "utility"
 		  }
 
 		}
@@ -266,12 +266,12 @@ func testUpcloudFirewallRulesInstanceConfig_update() string {
 		  hostname = "debian.example.com"
 		  plan     = "1xCPU-2GB"
 
-			template {
-      storage = "01000000-0000-4000-8000-000020050100"
-			}
+		  template {
+			storage = "01000000-0000-4000-8000-000020050100"
+		  }
 
 		  network_interface {
-      type = "utility"
+			type = "utility"
 		  }
 
 		}

--- a/upcloud/resource_upcloud_floating_ip_address_test.go
+++ b/upcloud/resource_upcloud_floating_ip_address_test.go
@@ -189,11 +189,9 @@ func testUpcloudFloatingIPAddressCreateWithServerConfig(serverNames []string, as
   			hostname = "mydebian.example.com"
   			plan     = "1xCPU-2GB"
 
-  			storage_devices {
-    			action = "create"
-    			size   = 10
-    			tier   = "maxiops"
-  			}
+        template {
+          storage = "01000000-0000-4000-8000-000020050100"
+        }
 
   			network_interface {
     			type = "public"

--- a/upcloud/resource_upcloud_floating_ip_address_test.go
+++ b/upcloud/resource_upcloud_floating_ip_address_test.go
@@ -189,9 +189,9 @@ func testUpcloudFloatingIPAddressCreateWithServerConfig(serverNames []string, as
   			hostname = "mydebian.example.com"
   			plan     = "1xCPU-2GB"
 
-        template {
-          storage = "01000000-0000-4000-8000-000020050100"
-        }
+  			template {
+  				storage = "01000000-0000-4000-8000-000020050100"
+  			}
 
   			network_interface {
     			type = "public"

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -166,7 +166,8 @@ func resourceUpCloudServer() *schema.Resource {
 			},
 			"storage_devices": {
 				Description: "A list of storage devices associated with the server",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
+				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"storage": {
@@ -192,12 +193,17 @@ func resourceUpCloudServer() *schema.Resource {
 			},
 			"template": {
 				Description: "",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				// NOTE: might want to make this optional
 				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: "The unique identifier for the storage",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
 						"address": {
 							Description: "The device address the storage will be attached to. Specify only the bus name (ide/scsi/virtio) to auto-select next available address from that bus.",
 							Type:        schema.TypeString,
@@ -228,7 +234,6 @@ func resourceUpCloudServer() *schema.Resource {
 							Description: "A valid storage UUID or template name",
 							Type:        schema.TypeString,
 							ForceNew:    true,
-							Optional:    true,
 							Required:    true,
 						},
 						"backup_rule": backupRuleSchema(),

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -229,6 +229,7 @@ func resourceUpCloudServer() *schema.Resource {
 							Type:        schema.TypeString,
 							ForceNew:    true,
 							Optional:    true,
+							Required:    true,
 						},
 						"backup_rule": backupRuleSchema(),
 					},

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -166,7 +166,7 @@ func resourceUpCloudServer() *schema.Resource {
 			},
 			"storage_devices": {
 				Description: "A list of storage devices associated with the server",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -365,7 +365,7 @@ func resourceUpCloudServerRead(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("network_interface", networkInterfaces)
 	}
 
-	storageDevices := []map[string]interface{}{}
+	storageDevices := []interface{}{}
 	log.Printf("[DEBUG] Configured storage devices in state: %+v", d.Get("storage_devices"))
 	log.Printf("[DEBUG] Actual storage devices on server: %v", server.StorageDevices)
 	for _, serverStorage := range server.StorageDevices {
@@ -526,8 +526,8 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 	}
 
 	if storage_devices, ok := d.GetOk("storage_devices"); ok {
-		storage_devices := storage_devices.([]interface{})
-		for _, storage_device := range storage_devices {
+		storage_devices := storage_devices.(*schema.Set)
+		for _, storage_device := range storage_devices.List() {
 			storage_device := storage_device.(map[string]interface{})
 			r.StorageDevices = append(r.StorageDevices, request.CreateServerStorageDevice{
 				Action:  "attach",

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -501,7 +501,7 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 	if template, ok := d.GetOk("template.0"); ok {
 		template := template.(map[string]interface{})
 		if template["title"].(string) == "" {
-			template["title"] = fmt.Sprintf("terraform-%s-disk-1", r.Hostname)
+			template["title"] = fmt.Sprintf("terraform-%s-disk", r.Hostname)
 		}
 		r.StorageDevices = append(
 			r.StorageDevices,

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -498,8 +498,11 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 		r.PasswordDelivery = deliveryMethod
 	}
 
-	if template, ok := d.GetOk("template"); ok {
+	if template, ok := d.GetOk("template.0"); ok {
 		template := template.(map[string]interface{})
+		if template["title"].(string) == "" {
+			template["title"] = fmt.Sprintf("terraform-%s-disk-1", r.Hostname)
+		}
 		r.StorageDevices = append(
 			r.StorageDevices,
 			request.CreateServerStorageDevice{

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -192,11 +192,11 @@ func resourceUpCloudServer() *schema.Resource {
 				},
 			},
 			"template": {
+				// TODO: add description
 				Description: "",
 				Type:        schema.TypeList,
-				// NOTE: might want to make this optional
-				Required: true,
-				MaxItems: 1,
+				Optional:    true,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -211,10 +211,9 @@ func resourceUpCloudServer() *schema.Resource {
 							Optional:    true,
 						},
 						"size": {
-							Description: "The size of the storage in gigabytes",
-							Type:        schema.TypeInt,
-							// TODO: update go-api to omit zero value from the payload and make this optional
-							Required:     true,
+							Description:  "The size of the storage in gigabytes",
+							Type:         schema.TypeInt,
+							Optional:     true,
 							ValidateFunc: validation.IntBetween(10, 2048),
 						},
 						// will be set to value matching the plan
@@ -376,9 +375,9 @@ func resourceUpCloudServerRead(ctx context.Context, d *schema.ResourceData, meta
 				"size":    serverStorage.Size,
 				"title":   serverStorage.Title,
 				"storage": d.Get("template.0.storage"),
-				// FIXME: backupRule cannot be derived from server.storageDevices payload, will not sync if changed elsewhere
+				"tier":    serverStorage.Tier,
+				// NOTE: backupRule cannot be derived from server.storageDevices payload, will not sync if changed elsewhere
 				"backup_rule": d.Get("template.0.backup_rule"),
-				// TODO: add when go-api updated ... "tier":   serverStorage.Tier,
 			}})
 		} else {
 			storageDevices = append(storageDevices, map[string]interface{}{

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -300,6 +300,15 @@ func resourceUpCloudServerCreate(ctx context.Context, d *schema.ResourceData, me
 		DesiredState: upcloud.ServerStateStarted,
 		Timeout:      time.Minute * 25,
 	})
+
+	// set template id from the payload (if passed)
+	if _, ok := d.GetOk("template.0"); ok {
+		d.Set("template", []map[string]interface{}{{
+			"id":      server.StorageDevices[0].UUID,
+			"storage": d.Get("template.0.storage"),
+		}})
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -168,17 +168,37 @@ func resourceUpCloudServer() *schema.Resource {
 			},
 			"storage_devices": {
 				Description: "A list of storage devices associated with the server",
-				Type:        schema.TypeList,
-				Required:    true,
-				ForceNew:    true,
-				MinItems:    1,
+				Type:        schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
-							Description: "The unique identifier for the storage",
+						"storage": {
+							Description: "A valid storage UUID",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"address": {
+							Description: "The device address the storage will be attached to. Specify only the bus name (ide/scsi/virtio) to auto-select next available address from that bus.",
 							Type:        schema.TypeString,
 							Computed:    true,
+							Optional:    true,
 						},
+						"type": {
+							Description:  "The device type the storage will be attached as",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "disk",
+							ValidateFunc: validation.StringInSlice([]string{"disk", "cdrom"}, false),
+						},
+					},
+				},
+			},
+			"template": {
+				Description: "",
+				Type:        schema.TypeSet,
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
 						"address": {
 							Description: "The device address the storage will be attached to. Specify only the bus name (ide/scsi/virtio) to auto-select next available address from that bus.",
 							Type:        schema.TypeString,
@@ -186,34 +206,22 @@ func resourceUpCloudServer() *schema.Resource {
 							ForceNew:    true,
 							Optional:    true,
 						},
-						"action": {
-							Description:  "The method used to create or attach the specified storage",
-							Type:         schema.TypeString,
-							ForceNew:     true,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"create", "clone", "attach"}, false),
-						},
 						"size": {
 							Description:  "The size of the storage in gigabytes",
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ForceNew:     true,
-							Default:      -1,
 							ValidateFunc: validation.IntBetween(10, 2048),
 						},
+						// will be set to maxiops
 						"tier": {
-							Description:  "The storage tier to use",
-							Type:         schema.TypeString,
-							Default:      "hdd",
-							ForceNew:     true,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"hdd", "maxiops"}, false),
+							Description: "The storage tier to use",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 						"title": {
 							Description:  "A short, informative description",
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							Computed:     true,
 							ValidateFunc: validation.StringLenBetween(0, 64),
 						},
@@ -222,43 +230,6 @@ func resourceUpCloudServer() *schema.Resource {
 							Type:        schema.TypeString,
 							ForceNew:    true,
 							Optional:    true,
-						},
-						"type": {
-							Description:  "The device type the storage will be attached as",
-							Type:         schema.TypeString,
-							ForceNew:     true,
-							Optional:     true,
-							Default:      "disk",
-							ValidateFunc: validation.StringInSlice([]string{"disk", "cdrom"}, false),
-						},
-						"backup_rule": {
-							Description: "The criteria to backup the storage",
-							Type:        schema.TypeSet,
-							MaxItems:    1,
-							ForceNew:    true,
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"interval": {
-										Description: "The weekday when the backup is created",
-										Type:        schema.TypeString,
-										ForceNew:    true,
-										Required:    true,
-									},
-									"time": {
-										Description: "The time of day when the backup is created",
-										Type:        schema.TypeString,
-										ForceNew:    true,
-										Required:    true,
-									},
-									"retention": {
-										Description: "The number of days before a backup is automatically deleted",
-										Type:        schema.TypeString,
-										ForceNew:    true,
-										Required:    true,
-									},
-								},
-							},
 						},
 					},
 				},

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -514,9 +514,11 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 	}
 
 	if storage_devices, ok := d.GetOk("storage_devices"); ok {
-		storage_devices := storage_devices.([]map[string]interface{})
+		storage_devices := storage_devices.([]interface{})
 		for _, storage_device := range storage_devices {
+			storage_device := storage_device.(map[string]interface{})
 			r.StorageDevices = append(r.StorageDevices, request.CreateServerStorageDevice{
+				Action:  "attach",
 				Address: storage_device["address"].(string),
 				Type:    storage_device["type"].(string),
 				Storage: storage_device["storage"].(string),

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -212,9 +212,10 @@ func resourceUpCloudServer() *schema.Resource {
 							Optional:    true,
 						},
 						"size": {
-							Description:  "The size of the storage in gigabytes",
-							Type:         schema.TypeInt,
-							Optional:     true,
+							Description: "The size of the storage in gigabytes",
+							Type:        schema.TypeInt,
+							// TODO: update go-api to omit zero value from the payload and make this optional
+							Required:     true,
 							ValidateFunc: validation.IntBetween(10, 2048),
 						},
 						// will be set to value matching the plan

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -446,11 +446,11 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	template := d.Get("template").([]map[string]interface{})
-	if len(template) > 0 {
-		// Delete server root disk
+	// Delete server root disk
+	if template, ok := d.GetOk("template.0"); ok {
+		template := template.(map[string]interface{})
 		deleteStorageRequest := &request.DeleteStorageRequest{
-			UUID: template[0]["id"].(string),
+			UUID: template["id"].(string),
 		}
 		log.Printf("[INFO] Deleting server storage (storage UUID: %s)", deleteStorageRequest.UUID)
 		err = client.DeleteStorage(deleteStorageRequest)

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -440,21 +440,16 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	storageDevices := d.Get("storage_devices").([]interface{})
-	for _, storageDevice := range storageDevices {
+	template := d.Get("template").([]map[string]interface{})
+	if len(template) > 0 {
 		// Delete server root disk
-		storageDevice := storageDevice.(map[string]interface{})
-		id := storageDevice["id"].(string)
-		action := storageDevice["action"].(string)
-		if action != request.CreateServerStorageDeviceActionAttach {
-			deleteStorageRequest := &request.DeleteStorageRequest{
-				UUID: id,
-			}
-			log.Printf("[INFO] Deleting server storage (storage UUID: %s)", id)
-			err = client.DeleteStorage(deleteStorageRequest)
-			if err != nil {
-				return diag.FromErr(err)
-			}
+		deleteStorageRequest := &request.DeleteStorageRequest{
+			UUID: template[0]["id"].(string),
+		}
+		log.Printf("[INFO] Deleting server storage (storage UUID: %s)", deleteStorageRequest.UUID)
+		err = client.DeleteStorage(deleteStorageRequest)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -491,6 +491,32 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 		r.PasswordDelivery = deliveryMethod
 	}
 
+	if template, ok := d.GetOk("template"); ok {
+		template := template.(map[string]interface{})
+		r.StorageDevices = append(
+			r.StorageDevices,
+			request.CreateServerStorageDevice{
+				Action:  "clone",
+				Address: template["address"].(string),
+				Size:    template["size"].(int),
+				Storage: template["storage"].(string),
+				Title:   template["title"].(string),
+			},
+		)
+		// TODO: handle backup_rule
+	}
+
+	if storage_devices, ok := d.GetOk("storage_devices"); ok {
+		storage_devices := storage_devices.([]map[string]interface{})
+		for _, storage_device := range storage_devices {
+			r.StorageDevices = append(r.StorageDevices, request.CreateServerStorageDevice{
+				Address: storage_device["address"].(string),
+				Type:    storage_device["type"].(string),
+				Storage: storage_device["storage"].(string),
+			})
+		}
+	}
+
 	networking, err := buildNetworkOpts(d, meta)
 	if err != nil {
 		return nil, err

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -434,10 +434,10 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChanges("template.0.title", "template.0.size", "template.0.backup_rule") {
 		template := d.Get("template.0").(map[string]interface{})
 		if _, err := client.ModifyStorage(&request.ModifyStorageRequest{
-			UUID:  template["id"].(string),
-			Size:  template["size"].(int),
-			Title: template["title"].(string),
-			// TODO: handle backup_rule
+			UUID:       template["id"].(string),
+			Size:       template["size"].(int),
+			Title:      template["title"].(string),
+			BackupRule: backup_rule(d.Get("template.0.backup_rule.0").(map[string]interface{})),
 		}); err != nil {
 			return diag.FromErr(err)
 		}

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -599,7 +599,6 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 			serverStorageDevice.Storage = source
 		}
 		r.StorageDevices = append(r.StorageDevices, serverStorageDevice)
-		// TODO: handle backup_rule
 	}
 
 	if storageDevices, ok := d.GetOk("storage_devices"); ok {

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -193,8 +193,7 @@ func resourceUpCloudServer() *schema.Resource {
 				},
 			},
 			"template": {
-				// TODO: add description
-				Description: "",
+				Description: "Block describing the preconfigured operating system",
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -465,22 +465,22 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 		o, n := d.GetChange("storage_devices")
 
 		// detach the devices that should be detached or sould be re-attached with different parameters
-		for _, storage_device := range o.(*schema.Set).Difference(n.(*schema.Set)).List() {
+		for _, storageDevices := range o.(*schema.Set).Difference(n.(*schema.Set)).List() {
 			if _, err := client.DetachStorage(&request.DetachStorageRequest{
 				ServerUUID: d.Id(),
-				Address:    storage_device.(map[string]interface{})["address"].(string),
+				Address:    storageDevices.(map[string]interface{})["address"].(string),
 			}); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 		// attach the storages that are new or have changed
-		for _, storage_device := range n.(*schema.Set).Difference(o.(*schema.Set)).List() {
-			storage_device := storage_device.(map[string]interface{})
+		for _, storageDevice := range n.(*schema.Set).Difference(o.(*schema.Set)).List() {
+			storageDevice := storageDevice.(map[string]interface{})
 			if _, err := client.AttachStorage(&request.AttachStorageRequest{
 				ServerUUID:  d.Id(),
-				Address:     storage_device["address"].(string),
-				StorageUUID: storage_device["storage"].(string),
-				Type:        storage_device["type"].(string),
+				Address:     storageDevice["address"].(string),
+				StorageUUID: storageDevice["storage"].(string),
+				Type:        storageDevice["type"].(string),
 			}); err != nil {
 				return diag.FromErr(err)
 			}
@@ -603,15 +603,15 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 		// TODO: handle backup_rule
 	}
 
-	if storage_devices, ok := d.GetOk("storage_devices"); ok {
-		storage_devices := storage_devices.(*schema.Set)
-		for _, storage_device := range storage_devices.List() {
-			storage_device := storage_device.(map[string]interface{})
+	if storageDevices, ok := d.GetOk("storage_devices"); ok {
+		storageDevices := storageDevices.(*schema.Set)
+		for _, storageDevice := range storageDevices.List() {
+			storageDevice := storageDevice.(map[string]interface{})
 			r.StorageDevices = append(r.StorageDevices, request.CreateServerStorageDevice{
 				Action:  "attach",
-				Address: storage_device["address"].(string),
-				Type:    storage_device["type"].(string),
-				Storage: storage_device["storage"].(string),
+				Address: storageDevice["address"].(string),
+				Type:    storageDevice["type"].(string),
+				Storage: storageDevice["storage"].(string),
 			})
 		}
 	}

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -437,7 +437,7 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 			UUID:       template["id"].(string),
 			Size:       template["size"].(int),
 			Title:      template["title"].(string),
-			BackupRule: backup_rule(d.Get("template.0.backup_rule.0").(map[string]interface{})),
+			BackupRule: backupRule(d.Get("template.0.backup_rule.0").(map[string]interface{})),
 		}); err != nil {
 			return diag.FromErr(err)
 		}
@@ -576,7 +576,7 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 			Title:   template["title"].(string),
 		}
 		if attr, ok := d.GetOk("template.0.backup_rule.0"); ok {
-			serverStorageDevice.BackupRule = backup_rule(attr.(map[string]interface{}))
+			serverStorageDevice.BackupRule = backupRule(attr.(map[string]interface{}))
 		}
 		if source := template["storage"].(string); source != "" {
 			// Assume template name is given and attempt map name to UUID

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -567,16 +567,17 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 		if template["title"].(string) == "" {
 			template["title"] = fmt.Sprintf("terraform-%s-disk", r.Hostname)
 		}
-		r.StorageDevices = append(
-			r.StorageDevices,
-			request.CreateServerStorageDevice{
-				Action:  "clone",
-				Address: template["address"].(string),
-				Size:    template["size"].(int),
-				Storage: template["storage"].(string),
-				Title:   template["title"].(string),
-			},
-		)
+		serverStorageDevice := request.CreateServerStorageDevice{
+			Action:  "clone",
+			Address: template["address"].(string),
+			Size:    template["size"].(int),
+			Storage: template["storage"].(string),
+			Title:   template["title"].(string),
+		}
+		if attr, ok := d.GetOk("template.0.backup_rule.0"); ok {
+			serverStorageDevice.BackupRule = backup_rule(attr.(map[string]interface{}))
+		}
+		r.StorageDevices = append(r.StorageDevices, serverStorageDevice)
 		// TODO: handle backup_rule
 	}
 

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
@@ -576,6 +577,27 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 		}
 		if attr, ok := d.GetOk("template.0.backup_rule.0"); ok {
 			serverStorageDevice.BackupRule = backup_rule(attr.(map[string]interface{}))
+		}
+		if source := template["storage"].(string); source != "" {
+			// Assume template name is given and attempt map name to UUID
+			if _, err := uuid.ParseUUID(source); err != nil {
+				l, err := meta.(*service.Service).GetStorages(
+					&request.GetStoragesRequest{
+						Type: upcloud.StorageTypeTemplate,
+					})
+
+				if err != nil {
+					return nil, err
+				}
+				for _, s := range l.Storages {
+					if s.Title == source {
+						source = s.UUID
+						break
+					}
+				}
+			}
+
+			serverStorageDevice.Storage = source
 		}
 		r.StorageDevices = append(r.StorageDevices, serverStorageDevice)
 		// TODO: handle backup_rule

--- a/upcloud/resource_upcloud_server_test.go
+++ b/upcloud/resource_upcloud_server_test.go
@@ -40,10 +40,8 @@ func testUpcloudServerInstanceConfig() string {
 			zone     = "fi-hel1"
 			hostname = "debian.example.com"
 
-			storage_devices {
-					action = "create"
-					size   = 10
-					tier   = "maxiops"
+			template {
+					storage = "01000000-0000-4000-8000-000020050100"
 			}
 
 			network_interface {
@@ -281,10 +279,8 @@ resource "upcloud_server" "my-server" {
 			hostname = "debian.example.com"
 			plan     = "1xCPU-2GB"
 
-			storage_devices {
-					action = "create"
-					size   = 10
-					tier   = "maxiops"
+			template {
+					storage = "01000000-0000-4000-8000-000020050100"
 			}
 
 			network_interface {
@@ -299,10 +295,8 @@ resource "upcloud_server" "my-server" {
 			hostname = "debian.example.com"
 			plan     = "2xCPU-4GB"
 
-			storage_devices {
-					action = "create"
-					size   = 10
-					tier   = "maxiops"
+			template {
+					storage = "01000000-0000-4000-8000-000020050100"
 			}
 
 			network_interface {
@@ -326,10 +320,8 @@ func testAccServerNetworkInterfaceConfig(nis ...networkInterface) string {
 			hostname = "debian.example.com"
 			plan     = "2xCPU-4GB"
 
-			storage_devices {
-					action = "create"
-					size   = 10
-					tier   = "maxiops"
+			template {
+					storage = "01000000-0000-4000-8000-000020050100"
 			}
 	`)
 

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"strconv"
 	"time"
 
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
@@ -35,7 +34,7 @@ func backupRuleSchema() *schema.Schema {
 				},
 				"retention": {
 					Description: "The number of days before a backup is automatically deleted",
-					Type:        schema.TypeString,
+					Type:        schema.TypeInt,
 					Required:    true,
 				},
 			},
@@ -407,7 +406,7 @@ func resourceUpCloudStorageRead(ctx context.Context, d *schema.ResourceData, met
 			map[string]interface{}{
 				"interval":  storage.BackupRule.Interval,
 				"time":      storage.BackupRule.Time,
-				"retention": strconv.Itoa(storage.BackupRule.Retention),
+				"retention": storage.BackupRule.Retention,
 			},
 		}
 

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -15,6 +15,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func backupRuleSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "The criteria to backup the storage",
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"interval": {
+					Description: "The weekday when the backup is created",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"time": {
+					Description: "The time of day when the backup is created",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"retention": {
+					Description: "The number of days before a backup is automatically deleted",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+			},
+		},
+	}
+}
+
 func resourceUpCloudStorage() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceUpCloudStorageCreate,
@@ -124,31 +152,7 @@ func resourceUpCloudStorage() *schema.Resource {
 					},
 				},
 			},
-			"backup_rule": {
-				Description: "The criteria to backup the storage",
-				Type:        schema.TypeSet,
-				MaxItems:    1,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"interval": {
-							Description: "The weekday when the backup is created",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-						"time": {
-							Description: "The time of day when the backup is created",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-						"retention": {
-							Description: "The number of days before a backup is automatically deleted",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-					},
-				},
-			},
+			"backup_rule": backupRuleSchema(),
 		},
 	}
 }

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -461,26 +461,7 @@ func resourceUpCloudStorageUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if d.HasChange("backup_rule") {
-		if v, ok := d.GetOk("backup_rule"); ok {
-			brs := v.(*schema.Set).List()
-			for _, br := range brs {
-				mBr := br.(map[string]interface{})
-
-				retentionValue, err := strconv.Atoi(mBr["retention"].(string))
-
-				if err != nil {
-					diag.FromErr(err)
-				}
-
-				backupRule := upcloud.BackupRule{
-					Interval:  mBr["interval"].(string),
-					Time:      mBr["time"].(string),
-					Retention: retentionValue,
-				}
-
-				r.BackupRule = &backupRule
-			}
-		}
+		r.BackupRule = backup_rule(d.Get("backup_rule.0").(map[string]interface{}))
 	}
 
 	_, err := client.WaitForStorageState(&request.WaitForStorageStateRequest{

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -399,7 +399,7 @@ func resourceUpCloudStorageRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	if _, ok := d.GetOk("backup_rule"); ok {
+	if storage.BackupRule != nil {
 		backupRule := []interface{}{
 			map[string]interface{}{
 				"interval":  storage.BackupRule.Interval,

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -257,10 +257,10 @@ func cloneStorage(
 	return nil
 }
 
-func backup_rule(backup_rule map[string]interface{}) *upcloud.BackupRule {
-	if interval, ok := backup_rule["interval"]; ok {
-		if time, ok := backup_rule["time"]; ok {
-			if retention, ok := backup_rule["retention"]; ok {
+func backupRule(backupRule map[string]interface{}) *upcloud.BackupRule {
+	if interval, ok := backupRule["interval"]; ok {
+		if time, ok := backupRule["time"]; ok {
+			if retention, ok := backupRule["retention"]; ok {
 				return &upcloud.BackupRule{
 					Interval:  interval.(string),
 					Time:      time.(string),
@@ -302,7 +302,7 @@ func createStorage(
 	}
 
 	if v, ok := d.GetOk("backup_rule.0"); ok {
-		createStorageRequest.BackupRule = backup_rule(v.(map[string]interface{}))
+		createStorageRequest.BackupRule = backupRule(v.(map[string]interface{}))
 	}
 
 	storage, err := client.CreateStorage(&createStorageRequest)
@@ -461,7 +461,7 @@ func resourceUpCloudStorageUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if d.HasChange("backup_rule") {
-		r.BackupRule = backup_rule(d.Get("backup_rule.0").(map[string]interface{}))
+		r.BackupRule = backupRule(d.Get("backup_rule.0").(map[string]interface{}))
 	}
 
 	_, err := client.WaitForStorageState(&request.WaitForStorageStateRequest{

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -399,7 +399,7 @@ func resourceUpCloudStorageRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	if storage.BackupRule != nil {
+	if storage.BackupRule != nil && storage.BackupRule.Retention > 0 {
 		backupRule := []interface{}{
 			map[string]interface{}{
 				"interval":  storage.BackupRule.Interval,


### PR DESCRIPTION
- Type fixes
- Fix sync issues (when state changed outside terraform)
- Changes in storage devices (or partially in template) will not trigger recreation of the server resource)
- Only the template will be recreated when server resource is recreated
- The template is managed within server, when deleting a server, also the template storage will be destroyed. (previously used to delete all the other storages as well)
- The "normal" storage devices will be managed as separate resources (need to remove the declaration to remove the storage. Removing storage from within the server block just detaches it). Can be attached to servers with:
    ```tf
    resource "upcloud_server" "server_resource_name" {
        zone     = "fi-hel1"
        ...
        storage_devices {
            address = "scsi"
            storage = upcloud_storage.storage_name.id # can also set to fixed uuid
            type = "disk"
        }
        storage_devices {
            storage = upcloud_storage.another_storage_name.id # can also set to fixed uuid
        }
    }

    resource "upload_storage" "storage_name" {
        # backup_rule { ... }
        clone: "target storage uuid"
        # import { ... }
        size = 25
        tier = "maxiops"
        title = "Storage device name"
        zone = "fi-hel1"
    }
    resource "upload_storage" "another_storage_name" {
        ...
    }
    ```
    - **NOTE**: did not rename the clone field, might want to either rename it or template.storage for consistency.

- Templates (introduced in this mr) differ from storages a bit. The templates are tied to server deployment, as they are setup when deploying a server. One can declare template followingly:

    ```tf
    resource "upcloud_server" "server_resource_name" {
        zone     = "fi-hel1"
        ...
        template {
          address: "scsi"
          # backup_rule: { ... }
          storage: "uuid for the public template"
          title: "Storage device name"
        }
    }
    ```
    - Dropped the `tier` from here, as for the plans hdd storages would be billed separately

## Other notes

- Did not address the code organisation here, something that should be discussed later on
- The acceptance tests need some love (will be addressed in a separate pr)
