### PR TITLE
Expose the ability to explicitly enable or disable metadata service.

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -50,6 +50,11 @@ func resourceUpCloudServer() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+			"metadata": {
+				Description: "Is the metadata service active for the server",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"cpu": {
 				Description:   "The number of CPU for the server",
 				Type:          schema.TypeInt,
@@ -493,6 +498,13 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 			r.Firewall = "on"
 		} else {
 			r.Firewall = "off"
+		}
+	}
+	if attr, ok := d.GetOk("metadata"); ok {
+		if attr.(bool) {
+			r.Metadata = upcloud.True
+		} else {
+			r.Metadata = upcloud.False
 		}
 	}
 	if attr, ok := d.GetOk("cpu"); ok {

--- a/website/docs/r/upcloud_server.html.markdown
+++ b/website/docs/r/upcloud_server.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
 * `hostname` - (Required) A valid domain name, e.g. host.example.com. The maximum length is 128 characters.
 * `zone` - (Required) - The zone in which the server will be hosted, e.g. fi-hel1. See [Zones API](https://developers.upcloud.com/1.3/5-zones/)
 * `firewall` - (Optional) Are firewall rules active for the server
+* `metadata` - (Optional) Is the metadata service active for the server
 * `cpu` - (Optional) The number of CPU for the server
 * `mem` - (Optional) The size of memory for the server
 * `template` - (Optional) The template to use during creation


### PR DESCRIPTION
Updated the Terraform provider the provide the ability to enable or disable the per-instance metadata service.