### PR TITLE
feature: WithRetry utility fn

### DIFF
--- a/upcloud/utils.go
+++ b/upcloud/utils.go
@@ -61,13 +61,13 @@ func min(x, y int) int {
 	return y
 }
 
-// WithRetry attempts to call the provided function until it has been successfully called or the number of calls exceeds retries
-func WithRetry(fn func() (interface{}, error), retries int, delay int) (interface{}, error) {
+// WithRetry attempts to call the provided function until it has been successfully called or the number of calls exceeds retries delaying the consecutive calls by given delay
+func WithRetry(fn func() (interface{}, error), retries int, delay time.Duration) (interface{}, error) {
 	var err error
 	var res interface{}
 	for count := 0; true; count++ {
 		if delay > 0 {
-			time.Sleep(time.Duration(delay) * time.Second)
+			time.Sleep(delay)
 		}
 		if count >= retries {
 			break

--- a/upcloud/utils.go
+++ b/upcloud/utils.go
@@ -1,6 +1,12 @@
 package upcloud
 
-import "github.com/UpCloudLtd/upcloud-go-api/upcloud"
+import (
+	"time"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+)
+
+var RetryDelay = 1000
 
 func FilterZoneIds(vs []upcloud.Zone, f func(upcloud.Zone) bool) []string {
 	vsf := make([]string, 0)
@@ -53,4 +59,25 @@ func min(x, y int) int {
 	}
 
 	return y
+}
+
+// WithRetry attempts to call the provided function until it has been successfully called or the number of calls exceeds retries
+func WithRetry(fn func() (interface{}, error), retries int, delay int) (interface{}, error) {
+	var err error
+	var res interface{}
+	for count := 0; true; count++ {
+		if delay > 0 {
+			time.Sleep(time.Duration(delay) * time.Second)
+		}
+		if count >= retries {
+			break
+		}
+		res, err = fn()
+		if err == nil {
+			return res, nil
+		} else {
+			continue
+		}
+	}
+	return nil, err
 }

--- a/upcloud/utils_test.go
+++ b/upcloud/utils_test.go
@@ -1,6 +1,7 @@
 package upcloud
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -56,6 +57,34 @@ func TestFilterNetworks(t *testing.T) {
 	}
 	if len(filtered2) != 3 {
 		t.Logf("filter2 returned wrong number of items: %d", len(filtered2))
+		t.Fail()
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	fail := func() (interface{}, error) {
+		return nil, fmt.Errorf("")
+	}
+	count := 0
+	successAftertree := func() (interface{}, error) {
+		if count < 3 {
+			count++
+			return nil, fmt.Errorf("")
+		} else {
+			return nil, nil
+		}
+	}
+	if _, err := WithRetry(fail, 3, 0); err == nil {
+		t.Log("should fail")
+		t.Fail()
+	}
+	if _, err := WithRetry(successAftertree, 4, 0); err != nil {
+		t.Log("should not fail")
+		t.Fail()
+	}
+	count = 0
+	if _, err := WithRetry(successAftertree, 3, 0); err == nil {
+		t.Log("should fail")
 		t.Fail()
 	}
 }


### PR DESCRIPTION
occasionally we want to re-attempt running a function in case it fails.

E.g. dispatching storage detach request at the same time causes the server go to a maintenance state (storages cannot be detached when server in maintenance state) for a short while. We don't want the provider to throw the failure user (while only one storage detached) when he attempts to fire multiple storage detach request at one go, so we'd use the helper fn to reattempt detaching storages.