### PR TITLE
WIP: Fix/server storage deletion

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -408,13 +408,8 @@ func resourceUpCloudServerRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*service.Service)
 
-	server, err := client.GetServerDetails(&request.GetServerDetailsRequest{
-		UUID: d.Id(),
-	})
+	server, err := verifyServerStopped(d.Id(), meta)
 	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := verifyServerStopped(server, meta); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -500,10 +495,8 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	if server.State == upcloud.ServerStateStarted {
-		if err := verifyServerStarted(server, meta); err != nil {
-			return diag.FromErr(err)
-		}
+	if _, err := verifyServerStarted(d.Id(), meta); err != nil {
+		return diag.FromErr(err)
 	}
 	return resourceUpCloudServerRead(ctx, d, meta)
 }
@@ -514,13 +507,7 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 
 	// Verify server is stopped before deletion
-	server, err := client.GetServerDetails(&request.GetServerDetailsRequest{
-		UUID: d.Id(),
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := verifyServerStopped(server, meta); err != nil {
+	if _, err := verifyServerStopped(d.Id(), meta); err != nil {
 		return diag.FromErr(err)
 	}
 	// Delete server
@@ -528,7 +515,8 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 		UUID: d.Id(),
 	}
 	log.Printf("[INFO] Deleting server (server UUID: %s)", d.Id())
-	if err := client.DeleteServer(deleteServerRequest); err != nil {
+	err := client.DeleteServer(deleteServerRequest)
+	if err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -715,48 +703,68 @@ func buildLoginOpts(v interface{}, meta interface{}) (*request.LoginUser, string
 	return r, deliveryMethod, nil
 }
 
-func verifyServerStopped(serverDetails *upcloud.ServerDetails, meta interface{}) error {
-	if serverDetails.State != upcloud.ServerStateStopped {
-		client := meta.(*service.Service)
+func verifyServerStopped(id string, meta interface{}) (*upcloud.ServerDetails, error) {
+	client := meta.(*service.Service)
+	// Get current server state
+	r := &request.GetServerDetailsRequest{
+		UUID: id,
+	}
+	server, err := client.GetServerDetails(r)
+	if err != nil {
+		return server, err
+	}
+	if server.State != upcloud.ServerStateStopped {
 		// Soft stop with 2 minute timeout, after which hard stop occurs
 		stopRequest := &request.StopServerRequest{
-			UUID:     serverDetails.UUID,
+			UUID:     id,
 			StopType: "soft",
 			Timeout:  time.Minute * 2,
 		}
-		log.Printf("[INFO] Stopping server (server UUID: %s)", serverDetails.UUID)
-		if _, err := client.StopServer(stopRequest); err != nil {
-			return err
+		log.Printf("[INFO] Stopping server (server UUID: %s)", id)
+		_, err := client.StopServer(stopRequest)
+		if err != nil {
+			return server, err
 		}
-		if _, err := client.WaitForServerState(&request.WaitForServerStateRequest{
-			UUID:         serverDetails.UUID,
+		_, err = client.WaitForServerState(&request.WaitForServerStateRequest{
+			UUID:         id,
 			DesiredState: upcloud.ServerStateStopped,
 			Timeout:      time.Minute * 5,
-		}); err != nil {
-			return err
+		})
+		if err != nil {
+			return server, err
 		}
 	}
-	return nil
+	return server, nil
 }
 
-func verifyServerStarted(serverDetails *upcloud.ServerDetails, meta interface{}) error {
-	if serverDetails.State != upcloud.ServerStateStarted {
-		client := meta.(*service.Service)
+func verifyServerStarted(id string, meta interface{}) (*upcloud.ServerDetails, error) {
+	client := meta.(*service.Service)
+	// Get current server state
+	r := &request.GetServerDetailsRequest{
+		UUID: id,
+	}
+	server, err := client.GetServerDetails(r)
+	if err != nil {
+		return server, err
+	}
+	if server.State != upcloud.ServerStateStarted {
 		startRequest := &request.StartServerRequest{
-			UUID:    serverDetails.UUID,
+			UUID:    id,
 			Timeout: time.Minute * 2,
 		}
-		log.Printf("[INFO] Starting server (server UUID: %s)", serverDetails.UUID)
-		if _, err := client.StartServer(startRequest); err != nil {
-			return err
+		log.Printf("[INFO] Starting server (server UUID: %s)", id)
+		_, err := client.StartServer(startRequest)
+		if err != nil {
+			return server, err
 		}
-		if _, err := client.WaitForServerState(&request.WaitForServerStateRequest{
-			UUID:         serverDetails.UUID,
+		_, err = client.WaitForServerState(&request.WaitForServerStateRequest{
+			UUID:         id,
 			DesiredState: upcloud.ServerStateStarted,
 			Timeout:      time.Minute * 5,
-		}); err != nil {
-			return err
+		})
+		if err != nil {
+			return server, err
 		}
 	}
-	return nil
+	return server, nil
 }

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -471,20 +471,15 @@ func resourceUpCloudStorageUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	// need to shut down server if resizing
 	if len(storageDetails.ServerUUIDs) > 0 && d.HasChange("size") {
-		server, err := client.GetServerDetails(&request.GetServerDetailsRequest{
-			UUID: d.Id(),
-		})
+		serverDetails, err := verifyServerStopped(storageDetails.ServerUUIDs[0], meta)
 		if err != nil {
-			return diag.FromErr(err)
-		}
-		if err := verifyServerStopped(server, meta); err != nil {
 			return diag.FromErr(err)
 		}
 		if _, err := WithRetry(func() (interface{}, error) { return client.ModifyStorage(&req) }, 20, time.Second*5); err != nil {
 			return diag.FromErr(err)
 		}
-		if server.State != upcloud.ServerStateStopped {
-			verifyServerStarted(server, meta)
+		if serverDetails.State != upcloud.ServerStateStopped {
+			verifyServerStarted(serverDetails.UUID, meta)
 		}
 	} else {
 		if _, err := client.ModifyStorage(&req); err != nil {
@@ -522,27 +517,26 @@ func resourceUpCloudStorageDelete(ctx context.Context, d *schema.ResourceData, m
 	if len(storageDetails.ServerUUIDs) > 0 {
 		serverUUID := storageDetails.ServerUUIDs[0]
 		// Get server details for retrieven the address used to detach the storage
-		server, err := client.GetServerDetails(&request.GetServerDetailsRequest{
+		serverDetails, err := client.GetServerDetails(&request.GetServerDetailsRequest{
 			UUID: serverUUID,
 		})
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		if storageDevice := server.StorageDevice(d.Id()); storageDevice != nil {
+		if storageDevice := serverDetails.StorageDevice(d.Id()); storageDevice != nil {
 			// ide devices can only be detached from stopped servers
 			if strings.HasPrefix(storageDevice.Address, "ide") {
-				if err = verifyServerStopped(server, meta); err != nil {
+				serverDetails, err = verifyServerStopped(serverUUID, meta)
+				if err != nil {
 					return diag.FromErr(err)
 				}
 			}
 			WithRetry(func() (interface{}, error) {
 				return client.DetachStorage(&request.DetachStorageRequest{ServerUUID: serverUUID, Address: storageDevice.Address})
 			}, 20, time.Second*3)
-			if strings.HasPrefix(storageDevice.Address, "ide") && server.State != upcloud.ServerStateStopped {
-				if err = verifyServerStarted(server, meta); err != nil {
-					return diag.FromErr(err)
-				}
+			if strings.HasPrefix(storageDevice.Address, "ide") && serverDetails.State != upcloud.ServerStateStopped {
+				verifyServerStarted(serverUUID, meta)
 			}
 		}
 	}

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -447,24 +447,6 @@ func resourceUpCloudStorageRead(ctx context.Context, d *schema.ResourceData, met
 func resourceUpCloudStorageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*service.Service)
 
-	r := &request.ModifyStorageRequest{
-		UUID: d.Id(),
-	}
-
-	if d.HasChange("size") {
-		_, newSize := d.GetChange("size")
-		r.Size = newSize.(int)
-	}
-
-	if d.HasChange("title") {
-		_, newTitle := d.GetChange("title")
-		r.Title = newTitle.(string)
-	}
-
-	if d.HasChange("backup_rule") {
-		r.BackupRule = backupRule(d.Get("backup_rule.0").(map[string]interface{}))
-	}
-
 	_, err := client.WaitForStorageState(&request.WaitForStorageStateRequest{
 		UUID:         d.Id(),
 		DesiredState: upcloud.StorageStateOnline,
@@ -474,7 +456,12 @@ func resourceUpCloudStorageUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	_, err = client.ModifyStorage(r)
+	_, err = client.ModifyStorage(&request.ModifyStorageRequest{
+		UUID:       d.Id(),
+		Size:       d.Get("size").(int),
+		Title:      d.Get("title").(string),
+		BackupRule: backupRule(d.Get("backup_rule.0").(map[string]interface{})),
+	})
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -524,7 +524,7 @@ func resourceUpCloudStorageDelete(ctx context.Context, d *schema.ResourceData, m
 			}
 			WithRetry(func() (interface{}, error) {
 				return client.DetachStorage(&request.DetachStorageRequest{ServerUUID: serverUUID, Address: storageDevice.Address})
-			}, 20, 1)
+			}, 20, time.Second*3)
 			if strings.HasPrefix(storageDevice.Address, "ide") {
 				// TODO: respect initial state when https://github.com/UpCloudLtd/terraform-provider-upcloud/pull/109 merged
 				verifyServerStopped(serverUUID, meta)

--- a/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/server.go
+++ b/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/server.go
@@ -208,3 +208,12 @@ func (s *ServerDetails) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+func (s *ServerDetails) StorageDevice(storageUUID string) *ServerStorageDevice {
+	for _, storageDevice := range s.StorageDevices {
+		if storageDevice.UUID == storageUUID {
+			return &storageDevice
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/server.go
+++ b/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/server.go
@@ -208,12 +208,3 @@ func (s *ServerDetails) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
-
-func (s *ServerDetails) StorageDevice(storageUUID string) *ServerStorageDevice {
-	for _, storageDevice := range s.StorageDevices {
-		if storageDevice.UUID == storageUUID {
-			return &storageDevice
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
Fixes issues that came up when testing

- Running Terraform with the config from the documentation => Pass
- Running a server with single storage resource (without "count" value) => Pass
- Running a server with multiple single resources (without "count" value)=> Pass
- Running a server with storage resources list ("count" value)=> Pass
- Running a server with multiple storage resources lust ("count" value) => Pass
- Resizing a server template storage => Pass
- Test doing changes from control panel like changing server's hostname and was detected in Terraform => Pass
- Resizing/Deleting storage resources:
  - Not attached to a server => Pass
  - Attached to a server => Fail with: Error: The operation is not allowed while the server 0003f7cc-b697-44fc-9839-50b9a1941e2a is in state 'started'. (SERVER_STATE_ILLEGAL).
- Updating template title, backup rule => Pass
- Updating server plan, hostname & firewall=> Pass
- Detach & Deleting a storage resource => fail with the same error:
  - Fail with: Error: The operation is not allowed while the server 0003f7cc-b697-44fc-9839-50b9a1941e2a is in state 'started'. (SERVER_STATE_ILLEGAL).
  - It seems that it tries to delete the resource before detaching.
