### PR TITLE
Add example of attaching a storage device to a server

### DIFF
--- a/website/docs/r/upcloud_storage.html.markdown
+++ b/website/docs/r/upcloud_storage.html.markdown
@@ -32,7 +32,7 @@ This storage resource will be backed up daily at 01:00 hours and each backup wil
       tier  = "maxiops"
       title = "My data collection backup"
       zone  = "fi-hel1"
-    
+
       backup_rule {
         interval  = "daily"
         time      = "0100"
@@ -50,7 +50,7 @@ This storage resource will have its content imported from an accessible website:
       tier  = "maxiops"
       title = "My imported data"
       zone  = "fi-hel1"
-    
+
       import {
         source = "http_import"
         source_location = "http://dl-cdn.alpinelinux.org/alpine/v3.12/releases/x86/alpine-standard-3.12.0-x86.iso"
@@ -67,7 +67,7 @@ This storage resource will have its content imported from a local file:
       tier  = "maxiops"
       title = "My imported data"
       zone  = "fi-hel1"
-    
+
       import {
         source = "direct_upload"
         source_location = "/tmp/upload_image.img"
@@ -87,9 +87,34 @@ the storage will be resized after cloning.
       tier  = "maxiops"
       title = "My cloned data"
       zone  = "fi-hel1"
-    
+
       clone {
         id = "01f936c9-38b2-4a10-b1fe-ad43d3078246"
+      }
+    }
+```
+
+The following HCL example shows the creation of the storage resource with the creation of a server resource which will attach the created storage resource.
+
+```hcl
+    resource "upcloud_storage" "example_storage" {
+      size  = 20
+      tier  = "maxiops"
+      title = "My storage"
+      zone  = "fi-hel1"
+    }
+
+    resource "upcloud_server" "example_server" {
+      zone     = "fi-hel1"
+      plan     = "1xCPU-1GB"
+      hostname = "terraform.example.tld"
+
+      network_interface {
+        type = "public"
+      }
+
+      storage_devices {
+        storage = upcloud_storage.example_storage[0].id
       }
     }
 ```


### PR DESCRIPTION
This PR adds an example of attaching a storage device to a server. The example is in the storage resource docs.

(this PR also removes some unnecessary whitespace)