### PR TITLE
Add missing zone attribute docs

### DIFF
--- a/website/docs/d/upcloud_zone.html.markdown
+++ b/website/docs/d/upcloud_zone.html.markdown
@@ -28,5 +28,6 @@ The following arguments can be supplied to the datasource.
 
 ## Attributes Reference
 
+* `id` - Unique label for the zone (same as `name`)
 * `description` - A real world value representing the zone, for example `London #1`.
-* `public` - . Identifies the zone as either public `true` or private `false`.
+* `public` - Identifies the zone as either public `true` or private `false`.

--- a/website/docs/d/upcloud_zones.html.markdown
+++ b/website/docs/d/upcloud_zones.html.markdown
@@ -38,8 +38,9 @@ data "upcloud_zones" "all_private_zones" {
 
 The following arguments can be supplied to the datasource.
 
-* `filter_type` - (Optional) Allows the zone_ids to be filtered by type, (public, private or all). Defaults to `all` 
+* `filter_type` - (Optional) Allows the zone_ids to be filtered by type, (public, private or all). Defaults to `all`
 
 ## Attributes Reference
 
-* `zone_ids` - A Collection of ids representing the available zones within UpCloud. 
+* `id` - UTC timestamp when the request was completed; used only for identifying the request in Terraform.
+* `zone_ids` - A Collection of ids representing the available zones within UpCloud.


### PR DESCRIPTION
This PR:

- adds docs for the "id" attribute of the zone & zones resources
- does some tidying up :)