### PR TITLE
fix(resource/router): fix creation of attachedNetworks for routers

### DIFF
--- a/upcloud/resource_upcloud_router.go
+++ b/upcloud/resource_upcloud_router.go
@@ -94,9 +94,8 @@ func resourceUpCloudRouterRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	attachedNetworks := make([]string, len(router.AttachedNetworks))
-
-	for _, network := range router.AttachedNetworks {
-		attachedNetworks = append(attachedNetworks, network.NetworkUUID)
+	for i, network := range router.AttachedNetworks {
+		attachedNetworks[i] = network.NetworkUUID
 	}
 
 	if err := d.Set("attached_networks", attachedNetworks); err != nil {


### PR DESCRIPTION
Previously, the initialization created a slice with len,cap=len(attachednetworks) filled with default values (eg. "" for strings).

After appending to the list, the list then had extra empty entries in the beginning ["", "uuid"] which were returned to TF. 

This is now fixed.