### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
-## 2.1.0
+## [Unreleased]
 
 ### Added
 
@@ -14,7 +14,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - Server not started after updating storage device
 
-## 2.0.0
+## [2.0.0]
 
 ### Added
 
@@ -42,9 +42,11 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - Addressed issue where a change in server networking would replace the previous storages (the template will still be created anew)
 - Inconsistent documentation
 
-## 1.0.0
+## [1.0.0]
 
-## 0.1.0
+Updated upcloud-go-api, added build/CI scripts, and repackaged 0.1.0 as 1.0.0.
+
+## [0.1.0]
 
 ### Added
 
@@ -79,3 +81,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - resource_upcloud_ip removed and replaced by resource_upcloud_floating_ip_address
 - resource_upcloud_firewall_rule removed and replaced by resource_upcloud_firewall_rules
 - resource_upcloud_zone removed and replaced by zone and zones datasources
+
+[Unreleased]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/1.0.0...2.0.0
+[1.0.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/0.1.0...1.0.0
+[0.0.1]: https://github.com/UpCloudLtd/terraform-provider-upcloud/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,4 +85,4 @@ Updated upcloud-go-api, added build/CI scripts, and repackaged 0.1.0 as 1.0.0.
 [Unreleased]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/2.0.0...HEAD
 [2.0.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/0.1.0...1.0.0
-[0.0.1]: https://github.com/UpCloudLtd/terraform-provider-upcloud/releases/tag/0.1.0
+[0.1.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/releases/tag/0.1.0


### PR DESCRIPTION
- 2.1.0 is not released => changes to "Unreleased"
- adds links for versions
- adds notes about 1.0.0