### PR TITLE
feat(server): add tags attribute

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -72,3 +72,13 @@ func WithRetry(fn func() (interface{}, error), retries int, delay time.Duration)
 	}
 	return nil, err
 }
+
+// ExpandStrings expands a terraform interface to slice of str
+func ExpandStrings(data interface{}) []string {
+	strSlice := []string{}
+	for _, s := range data.([]interface{}) {
+		strSlice = append(strSlice, s.(string))
+	}
+
+	return strSlice
+}


### PR DESCRIPTION
Add tags attribute in server resource.
Since the API/SDK don't allow managing tags from /server resource, we need to use /tag resource. Basically on any creation/update we handle the tags separately then we add/remove them from server resource