### PR TITLE
fix(router): allow detaching router and deleting attached routers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/terraform-provider-upcloud
 go 1.14
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210127073406-2964ed7e5972
+	github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210127073406-2964ed7e5972 h1:OUrt9phz41jCKOgqu3Iq8KH+5OfyfgcdFT28R9QLN0Y=
 github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210127073406-2964ed7e5972/go.mod h1:nKv1Y0cTJTGYSd3lEcFfEnbPPiIj3gT4lJzV0ZfTlpQ=
+github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b h1:WDp7g7xKKvXJvfEPicT8A7dLwMDgEN5cb5fgnsgvzJw=
+github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b/go.mod h1:nKv1Y0cTJTGYSd3lEcFfEnbPPiIj3gT4lJzV0ZfTlpQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/upcloud/resource_upcloud_network.go
+++ b/upcloud/resource_upcloud_network.go
@@ -234,11 +234,6 @@ func resourceUpCloudNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 		req.Name = v.(string)
 	}
 
-	if d.HasChange("router") {
-		_, v := d.GetChange("router")
-		req.Router = v.(string)
-	}
-
 	if d.HasChange("ip_network") {
 		v := d.Get("ip_network")
 

--- a/upcloud/resource_upcloud_network.go
+++ b/upcloud/resource_upcloud_network.go
@@ -260,6 +260,18 @@ func resourceUpCloudNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	if d.HasChange("router") {
+		_, v := d.GetChange("router")
+		if v.(string) == "" {
+			err = client.DetachNetworkRouter(&request.DetachNetworkRouterRequest{NetworkUUID: d.Id()})
+		} else {
+			err = client.AttachNetworkRouter(&request.AttachNetworkRouterRequest{NetworkUUID: d.Id(), RouterUUID: v.(string)})
+		}
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	d.SetId(network.UUID)
 
 	return nil

--- a/upcloud/resource_upcloud_router_test.go
+++ b/upcloud/resource_upcloud_router_test.go
@@ -90,6 +90,109 @@ func TestAccUpCloudRouter_import(t *testing.T) {
 	})
 }
 
+func TestAccUpCloudRouter_detach(t *testing.T) {
+	var providers []*schema.Provider
+	var router upcloud.Router
+	var network upcloud.Network
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckRouterNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				// first create network and router attached
+				Config: testAccRouterNetworkConfig("testrouter", "testnetwork", true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouterExists("upcloud_router.terraform_test_router", &router),
+					testAccCheckNetworkExists("upcloud_network.terraform_test_network", &network),
+				),
+			},
+			{
+				ResourceName:      "upcloud_router.terraform_test_router",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					for _, s := range states {
+						if s.Attributes["attached_networks.#"] != "1" {
+							return fmt.Errorf("expected 1 network, got %v", s.Attributes["attached_networks.#"])
+						}
+					}
+					return nil
+				},
+			},
+			{
+				// and then change them to detached
+				Config: testAccRouterNetworkConfig("testrouter", "testnetwork", true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouterExists("upcloud_router.terraform_test_router", &router),
+					testAccCheckNetworkExists("upcloud_network.terraform_test_network", &network),
+				),
+			},
+			{
+				ResourceName:      "upcloud_router.terraform_test_router",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					for _, s := range states {
+						if s.Attributes["attached_networks.#"] != "0" {
+							return fmt.Errorf("expected 0 networks, got %v", s.Attributes["attached_networks.#"])
+						}
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccUpCloudRouter_attachedDelete(t *testing.T) {
+	var providers []*schema.Provider
+	var router upcloud.Router
+	var network upcloud.Network
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckRouterNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				// first create network and router attached
+				Config: testAccRouterNetworkConfig("testrouter", "testnetwork", true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouterExists("upcloud_router.terraform_test_router", &router),
+					testAccCheckNetworkExists("upcloud_network.terraform_test_network", &network),
+				),
+			},
+			{
+				ResourceName:      "upcloud_router.terraform_test_router",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					for _, s := range states {
+						if s.Attributes["attached_networks.#"] != "1" {
+							return fmt.Errorf("expected 1 network, got %v", s.Attributes["attached_networks.#"])
+						}
+					}
+					return nil
+				},
+			},
+			{
+				// and then try to delete the router
+				Config: testAccRouterNetworkConfig("testrouter", "testnetwork", false, false),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						_, ok := s.RootModule().Resources["upcloud_router.terraform_test_router"]
+						if ok {
+							return fmt.Errorf("router found, expected to be deleted")
+						}
+						return nil
+					},
+					testAccCheckNetworkExists("upcloud_network.terraform_test_network", &network),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRouterExists(resourceName string, router *upcloud.Router) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Look for the full resource name and error if not found
@@ -115,6 +218,36 @@ func testAccCheckRouterExists(resourceName string, router *upcloud.Router) resou
 
 		// Update the reference the remote located router
 		*router = *latest
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkExists(resourceName string, network *upcloud.Network) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Look for the full resource name and error if not found
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		// The provider has not set the ID for the resource
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Network ID is set")
+		}
+
+		// Use the API SDK to locate the remote resource.
+		client := testAccProvider.Meta().(*service.Service)
+		latest, err := client.GetNetworkDetails(&request.GetNetworkDetailsRequest{
+			UUID: rs.Primary.ID,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		// Update the reference the remote located network
+		*network = *latest
 
 		return nil
 	}
@@ -153,9 +286,72 @@ func testAccCheckRouterDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckRouterNetworkDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*service.Service)
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "upcloud_router":
+			routers, err := client.GetRouters()
+			if err != nil {
+				return fmt.Errorf("[WARN] Error listing routers when deleting upcloud router (%s): %s", rs.Primary.ID, err)
+			}
+
+			for _, router := range routers.Routers {
+				if router.UUID == rs.Primary.ID {
+					// service still found
+					return fmt.Errorf("[WARN] Tried deleting Router (%s), but was still found", rs.Primary.ID)
+				}
+			}
+		case "upcloud_network":
+			networks, err := client.GetNetworks()
+			if err != nil {
+				return fmt.Errorf("[WARN] Error listing networks when deleting upcloud network (%s): %s", rs.Primary.ID, err)
+			}
+
+			for _, network := range networks.Networks {
+				if network.UUID == rs.Primary.ID {
+					// service still found
+					return fmt.Errorf("[WARN] Tried deleting network (%s), but was still found", rs.Primary.ID)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func testAccRouterConfig(name string) string {
 	return fmt.Sprintf(`
 resource "upcloud_router" "my_example_router" {
   name = "%s"
 }`, name)
+}
+
+func testAccRouterNetworkConfig(routerName, networkName string, includeRouter, routerAttached bool) string {
+	routerAttachment := ""
+	if routerAttached {
+		routerAttachment = "router = upcloud_router.terraform_test_router.id"
+	}
+	routerDefinition := ""
+	if includeRouter {
+		routerDefinition = fmt.Sprintf(`resource "upcloud_router" "terraform_test_router" {
+  name = "%s"
+}`, routerName)
+	}
+
+	return fmt.Sprintf(`
+%s 
+
+resource "upcloud_network" "terraform_test_network" {
+  name = "%s"
+  zone = "fi-hel1"
+
+  %s
+
+  ip_network {
+    address            = "10.0.0.0/24"
+    dhcp               = true
+    family  = "IPv4"
+  }
+}
+`, routerDefinition, networkName, routerAttachment)
 }

--- a/upcloud/resource_upcloud_router_test.go
+++ b/upcloud/resource_upcloud_router_test.go
@@ -111,14 +111,7 @@ func TestAccUpCloudRouter_detach(t *testing.T) {
 				ResourceName:      "upcloud_router.terraform_test_router",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					for _, s := range states {
-						if s.Attributes["attached_networks.#"] != "1" {
-							return fmt.Errorf("expected 1 network, got %v", s.Attributes["attached_networks.#"])
-						}
-					}
-					return nil
-				},
+				Check:             resource.TestCheckResourceAttr("upcloud_router.terraform_test_router", "attached_networks.#", "1"),
 			},
 			{
 				// and then change them to detached
@@ -132,14 +125,7 @@ func TestAccUpCloudRouter_detach(t *testing.T) {
 				ResourceName:      "upcloud_router.terraform_test_router",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					for _, s := range states {
-						if s.Attributes["attached_networks.#"] != "0" {
-							return fmt.Errorf("expected 0 networks, got %v", s.Attributes["attached_networks.#"])
-						}
-					}
-					return nil
-				},
+				Check:             resource.TestCheckResourceAttr("upcloud_router.terraform_test_router", "attached_networks.#", "0"),
 			},
 		},
 	})
@@ -166,14 +152,7 @@ func TestAccUpCloudRouter_attachedDelete(t *testing.T) {
 				ResourceName:      "upcloud_router.terraform_test_router",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					for _, s := range states {
-						if s.Attributes["attached_networks.#"] != "1" {
-							return fmt.Errorf("expected 1 network, got %v", s.Attributes["attached_networks.#"])
-						}
-					}
-					return nil
-				},
+				Check:             resource.TestCheckResourceAttr("upcloud_router.terraform_test_router", "attached_networks.#", "1"),
 			},
 			{
 				// and then try to delete the router

--- a/vendor/github.com/UpCloudLtd/upcloud-go-api/internal/globals.go
+++ b/vendor/github.com/UpCloudLtd/upcloud-go-api/internal/globals.go
@@ -1,3 +1,3 @@
 package globals
 
-var Version = "3.0.0"
+var Version = "4.0.0"

--- a/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/request/network.go
+++ b/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/request/network.go
@@ -60,7 +60,6 @@ type ModifyNetworkRequest struct {
 
 	Name       string                 `json:"name,omitempty"`
 	Zone       string                 `json:"zone,omitempty"`
-	Router     string                 `json:"router,omitempty"`
 	IPNetworks upcloud.IPNetworkSlice `json:"ip_networks,omitempty"`
 }
 
@@ -89,6 +88,43 @@ type DeleteNetworkRequest struct {
 // RequestURL implements the Request interface.
 func (r *DeleteNetworkRequest) RequestURL() string {
 	return fmt.Sprintf("/network/%s", r.UUID)
+}
+
+// AttachNetworkRouterRequest represents a request to attach a particular router to a network
+type AttachNetworkRouterRequest struct {
+	NetworkUUID string `json:"-"`
+	RouterUUID  string `json:"router"`
+}
+
+// RequestURL implements the Request interface
+func (r *AttachNetworkRouterRequest) RequestURL() string {
+	return (&ModifyNetworkRequest{UUID: r.NetworkUUID}).RequestURL()
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (r AttachNetworkRouterRequest) MarshalJSON() ([]byte, error) {
+	type localAttachNetworkRouterRequest AttachNetworkRouterRequest
+	v := struct {
+		AttachNetworkRouterRequest localAttachNetworkRouterRequest `json:"network"`
+	}{}
+	v.AttachNetworkRouterRequest = localAttachNetworkRouterRequest(r)
+
+	return json.Marshal(&v)
+}
+
+// DetachNetworkRouterRequest represents a request to detach a router from a network
+type DetachNetworkRouterRequest struct {
+	NetworkUUID string `json:"-"`
+}
+
+// RequestURL implements the Request interface
+func (r *DetachNetworkRouterRequest) RequestURL() string {
+	return (&ModifyNetworkRequest{UUID: r.NetworkUUID}).RequestURL()
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (r DetachNetworkRouterRequest) MarshalJSON() ([]byte, error) {
+	return []byte(`{ "network": { "router": null } }`), nil
 }
 
 // GetServerNetworksRequest represents a request to get the networks

--- a/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/service/network.go
+++ b/vendor/github.com/UpCloudLtd/upcloud-go-api/upcloud/service/network.go
@@ -15,6 +15,8 @@ type Network interface {
 	GetNetworkDetails(r *request.GetNetworkDetailsRequest) (*upcloud.Network, error)
 	ModifyNetwork(r *request.ModifyNetworkRequest) (*upcloud.Network, error)
 	DeleteNetwork(r *request.DeleteNetworkRequest) error
+	AttachNetworkRouter(r *request.AttachNetworkRouterRequest) error
+	DetachNetworkRouter(r *request.DetachNetworkRouterRequest) error
 	GetServerNetworks(r *request.GetServerNetworksRequest) (*upcloud.Networking, error)
 	CreateNetworkInterface(r *request.CreateNetworkInterfaceRequest) (*upcloud.Interface, error)
 	ModifyNetworkInterface(r *request.ModifyNetworkInterfaceRequest) (*upcloud.Interface, error)
@@ -123,6 +125,28 @@ func (s *Service) DeleteNetwork(r *request.DeleteNetworkRequest) error {
 		return parseJSONServiceError(err)
 	}
 
+	return nil
+}
+
+// AttachNetworkRouter attaches a router to the specified network.
+func (s *Service) AttachNetworkRouter(r *request.AttachNetworkRouterRequest) error {
+	requestBody, _ := json.Marshal(r)
+	_, err := s.client.PerformJSONPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	if err != nil {
+		return parseJSONServiceError(err)
+	}
+	return nil
+}
+
+// DetachNetworkRouter detaches a router from the specified network.
+func (s *Service) DetachNetworkRouter(r *request.DetachNetworkRouterRequest) error {
+	requestBody, _ := json.Marshal(r)
+	_, err := s.client.PerformJSONPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
+
+	if err != nil {
+		return parseJSONServiceError(err)
+	}
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 cloud.google.com/go/storage
-# github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210127073406-2964ed7e5972
+# github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210525102709-661419a1956b
 ## explicit
 github.com/UpCloudLtd/upcloud-go-api/internal
 github.com/UpCloudLtd/upcloud-go-api/upcloud


### PR DESCRIPTION
- pulls in go-api 4.0.0, allowing fot detaching to work
- implement the new go-api detachment methods
- make sure routers are detached when deleting

Fixes #137 