### PR TITLE
chore(ci): bump go version to support darwin arm64

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.14
+ARG GO_VERSION=1.16
 FROM golang:$GO_VERSION
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install unzip


### PR DESCRIPTION
Signed-off-by: Amine Kherbouche <kaminek92@gmail.com>