### PR TITLE
Fixes for local dev

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,8 +3,9 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 
 MODULE   = $(shell env GO111MODULE=on go list -m)
-VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
+GIT_VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
 			cat $(CURDIR)/.version 2> /dev/null || echo v0)
+VERSION = $(shell echo $(GIT_VERSION) | sed 's/^v//' | sed 's/-.*//')
 
 PROVIDER_HOSTNAME=registry.upcloud.com
 PROVIDER_NAMESPACE=upcloud
@@ -18,7 +19,7 @@ build: fmtcheck
 	@mkdir -p $(PROVIDER_PATH)
 	go build \
 		-tags release \
-		-ldflags '-X $(MODULE)/internal/config.Version=$(VERSION)' \
+		-ldflags '-X $(MODULE)/internal/config.Version=$(GIT_VERSION)' \
 		-o $(PROVIDER_PATH)/terraform-provider-$(PROVIDER_NAMESPACE)_v$(VERSION)
 
 build_0_12: fmtcheck

--- a/README.md
+++ b/README.md
@@ -251,6 +251,21 @@ value specified in the makefile and in this case the version is 2.0.0.
 
 After the provider has been built you can then use standard terraform commands.
 
+Use this provider config with the local version:
+
+```
+terraform {
+  required_providers {
+    upcloud = {
+      source = "registry.upcloud.com/upcloud/upcloud"
+      version = "~> 2.1"
+    }
+  }
+}
+```
+
+**Testing**
+
 In order to test the provider, you can simply run `make test`.
 
 ```sh
@@ -313,7 +328,8 @@ Run Terraform files, e.g. the examples:
 
 ```sh
 cd /tmp
-cp /work/examples/01_server.tf .
+cp /work/examples/server.tf .
+# change the provider source in server.tf to "registry.upcloud.com/upcloud/upcloud"
 export UPCLOUD_USERNAME="upcloud-api-access-enabled-user"
 export UPCLOUD_PASSWORD="verysecretpassword"
 terraform init
@@ -336,7 +352,7 @@ The UpCloud makefile supports the old, Terraform 0.12 style where plugin
 directory structure is not relevant and only the binary name matters.
 
 The following make command can be executed to build and place the provider in
-the Go binary directory. Make sure your PATH includes the Go binary directory. 
+the Go binary directory. Make sure your PATH includes the Go binary directory.
 
 ```sh
 make build_0_12


### PR DESCRIPTION
- fix the path being generated by `make build` (the version is supposed to be e.g. "2.1.1" but it was "v2.1.1" or "v2.1.1-dirty")
- add extra help to README