### PR TITLE
Change server/tags from List to Set

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -77,7 +77,7 @@ func WithRetry(fn func() (interface{}, error), retries int, delay time.Duration)
 // ExpandStrings expands a terraform interface to slice of str
 func ExpandStrings(data interface{}) []string {
 	strSlice := []string{}
-	for _, s := range data.([]interface{}) {
+	for _, s := range data.(*schema.Set).List() {
 		strSlice = append(strSlice, s.(string))
 	}
 

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -81,7 +81,7 @@ func resourceUpCloudServer() *schema.Resource {
 			},
 			"tags": {
 				Description: "The server related tags",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
I was encountering an annoyance where some of my server/tags would show changed with each plan and be removed and readded with each apply. It would complete the job successfully, just that it should not have been reporting changes being required each run.

I found that server/tags is defined as a TypeList, where it seemed it should be a TypeSet, which appears to be what the deprecated tags resource used.

This patch changes server/tags to be defined as a TypeSet, and updates the ExpandStrings utility method to work with the Set. This change resolved my issue and I did not notice any side-effects in my testing (server create, add tag, remove tag, server delete).

The change seems pretty trivial to me, but this is my first time editing Go, so I can only say that it appears to work, not that it is correct.

Thank you.