### PR TITLE
fix(server): prevent empty tags from replanning

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -379,7 +379,12 @@ func resourceUpCloudServerRead(ctx context.Context, d *schema.ResourceData, meta
 	_ = d.Set("mem", server.MemoryAmount)
 	_ = d.Set("metadata", server.Metadata.Bool())
 	_ = d.Set("plan", server.Plan)
-	_ = d.Set("tags", server.Tags)
+
+	// XXX: server.Tags returns an empty slice rather than nil when it's empty
+	if len(server.Tags) > 0 {
+		_ = d.Set("tags", server.Tags)
+	}
+
 	if server.Firewall == "on" {
 		_ = d.Set("firewall", true)
 	} else {

--- a/upcloud/resource_upcloud_server_test.go
+++ b/upcloud/resource_upcloud_server_test.go
@@ -13,6 +13,55 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestUpcloudServer_minimal(t *testing.T) {
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "upcloud_server" "min" {
+            hostname = "min-server" 
+						zone     = "fi-hel2"
+
+						template {
+								storage = "01000000-0000-4000-8000-000020050100"
+								size = 10
+						}
+
+						network_interface {
+							type = "utility"
+						}
+					}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("upcloud_server.min", "zone", "fi-hel2"),
+					resource.TestCheckResourceAttr("upcloud_server.min", "hostname", "min-server"),
+					resource.TestCheckNoResourceAttr("upcloud_server.min", "tags"),
+				),
+			},
+			{
+				Config: `
+					resource "upcloud_server" "min" {
+            hostname = "min-server" 
+						zone     = "fi-hel2"
+
+						template {
+								storage = "01000000-0000-4000-8000-000020050100"
+								size = 10
+						}
+
+						network_interface {
+							type = "utility"
+						}
+					}`,
+				ExpectNonEmptyPlan: false, //ensure nothing changed
+			},
+		},
+	})
+}
+
 func TestUpcloudServer_basic(t *testing.T) {
 	var providers []*schema.Provider
 


### PR DESCRIPTION
Given a server without tags, the SDK returns an empty array tag for that server. Terraform local state is that case is a nil tag array. So trying a replan will show a diff between the returned SDK values and the local state.

That patch considers an empty tag array as nil.



Signed-off-by: Amine Kherbouche <kaminek92@gmail.com>