### PR TITLE
fix(tests): disable parallelism for router tests

### DIFF
--- a/upcloud/resource_upcloud_network_test.go
+++ b/upcloud/resource_upcloud_network_test.go
@@ -93,7 +93,7 @@ func TestAccUpCloudNetwork_withRouter(t *testing.T) {
 	cidr := fmt.Sprintf("10.0.%d.0/24", subnet)
 	gateway := fmt.Sprintf("10.0.%d.1", subnet)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccUpCloudNetwork_amendWithRouter(t *testing.T) {
 	cidr := fmt.Sprintf("10.0.%d.0/24", subnet)
 	gateway := fmt.Sprintf("10.0.%d.1", subnet)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		Steps: []resource.TestStep{

--- a/upcloud/resource_upcloud_router_test.go
+++ b/upcloud/resource_upcloud_router_test.go
@@ -19,7 +19,7 @@ func TestAccUpCloudRouter(t *testing.T) {
 	var router upcloud.Router
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckRouterDestroy,
@@ -42,7 +42,7 @@ func TestAccUpCloudRouter_update(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	updateName := fmt.Sprintf("tf-test-update-%s", acctest.RandString(10))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckRouterDestroy,
@@ -94,7 +94,7 @@ func TestAccUpCloudRouter_detach(t *testing.T) {
 	var providers []*schema.Provider
 	var router upcloud.Router
 	var network upcloud.Network
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckRouterNetworkDestroy,


### PR DESCRIPTION
Remove parallelism for router related test because the API not stable for that endpoint and concurrent creation may end up with a 500.

Signed-off-by: Amine Kherbouche <kaminek92@gmail.com>