### PR TITLE
fix: make sure either storage devices or template are required

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -223,10 +223,11 @@ func resourceUpCloudServer() *schema.Resource {
 				},
 			},
 			"template": {
-				Description: "Block describing the preconfigured operating system",
-				Type:        schema.TypeList,
-				Optional:    true,
-				MaxItems:    1,
+				Description:  "Block describing the preconfigured operating system",
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				AtLeastOneOf: []string{"storage_devices", "template"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {


### PR DESCRIPTION
This PR adds a simple check to server schema to make sure either `storage_devices` or `template` block is set on server resource