### PR TITLE
feat(server): increase title length from 64 to 255

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-const serverTitleLength int = 128
+const serverTitleLength int = 255
 
 func resourceUpCloudServer() *schema.Resource {
 	return &schema.Resource{

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-const cloudServerTitleLength int = 64
+const serverTitleLength int = 128
 
 func resourceUpCloudServer() *schema.Resource {
 	return &schema.Resource{
@@ -42,7 +42,7 @@ func resourceUpCloudServer() *schema.Resource {
 				Description:  "A short, informational description",
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, cloudServerTitleLength),
+				ValidateFunc: validation.StringLenBetween(1, serverTitleLength),
 			},
 			"zone": {
 				Description: "The zone in which the server will be hosted",
@@ -349,7 +349,7 @@ func resourceUpCloudServerCreate(ctx context.Context, d *schema.ResourceData, me
 	if _, ok := d.GetOk("title"); ok {
 		r.Title = d.Get("title").(string)
 	} else {
-		r.Title = cloudServerDefaultTitleFromHostname(d.Get("hostname").(string))
+		r.Title = serverDefaultTitleFromHostname(d.Get("hostname").(string))
 	}
 
 	serverDetails, err := client.CreateServer(r)
@@ -409,7 +409,7 @@ func resourceUpCloudServerRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 	_ = d.Set("hostname", server.Hostname)
-	if server.Title != cloudServerDefaultTitleFromHostname(server.Hostname) {
+	if server.Title != serverDefaultTitleFromHostname(server.Hostname) {
 		_ = d.Set("title", server.Title)
 	} else {
 		_ = d.Set("title", nil)
@@ -563,7 +563,7 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 	if attr, ok := d.GetOk("title"); ok {
 		r.Title = attr.(string)
 	} else {
-		r.Title = cloudServerDefaultTitleFromHostname(d.Get("hostname").(string))
+		r.Title = serverDefaultTitleFromHostname(d.Get("hostname").(string))
 	}
 
 	r.Metadata = upcloud.FromBool(d.Get("metadata").(bool))
@@ -760,10 +760,10 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func cloudServerDefaultTitleFromHostname(hostname string) string {
+func serverDefaultTitleFromHostname(hostname string) string {
 	const suffix string = " (managed by terraform)"
-	if len(hostname)+len(suffix) > cloudServerTitleLength {
-		hostname = fmt.Sprintf("%s…", hostname[:cloudServerTitleLength-len(suffix)-1])
+	if len(hostname)+len(suffix) > serverTitleLength {
+		hostname = fmt.Sprintf("%s…", hostname[:serverTitleLength-len(suffix)-1])
 	}
 	return fmt.Sprintf("%s%s", hostname, suffix)
 }

--- a/upcloud/resource_upcloud_server_test.go
+++ b/upcloud/resource_upcloud_server_test.go
@@ -961,15 +961,15 @@ func testAccServerNetworkInterfaceConfig(nis ...networkInterface) string {
 	return builder.String()
 }
 
-func TestCloudServerDefaultTitle(t *testing.T) {
-	want := "terraformterraformterraformterraformterr… (managed by terraform)"
-	got := cloudServerDefaultTitleFromHostname("terraformterraformterraformterraformterraformterraformterraform")
+func TestServerDefaultTitle(t *testing.T) {
+	want := "terraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterra… (managed by terraform)"
+	got := serverDefaultTitleFromHostname("terraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraform")
 	if want != got {
 		t.Errorf("cloudServerDefaultTitleFromHostname failed want '%s' got '%s'", want, got)
 	}
 
 	want = "terraform (managed by terraform)"
-	got = cloudServerDefaultTitleFromHostname("terraform")
+	got = serverDefaultTitleFromHostname("terraform")
 	if want != got {
 		t.Errorf("cloudServerDefaultTitleFromHostname failed want '%s' got '%s'", want, got)
 	}

--- a/upcloud/resource_upcloud_server_test.go
+++ b/upcloud/resource_upcloud_server_test.go
@@ -962,8 +962,10 @@ func testAccServerNetworkInterfaceConfig(nis ...networkInterface) string {
 }
 
 func TestServerDefaultTitle(t *testing.T) {
-	want := "terraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterra… (managed by terraform)"
-	got := serverDefaultTitleFromHostname("terraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraformterraform")
+	longHostname := strings.Repeat("x", 255)
+	suffixLength := 24
+	want := fmt.Sprintf("%s… (managed by terraform)", longHostname[0:255-suffixLength])
+	got := serverDefaultTitleFromHostname(longHostname)
 	if want != got {
 		t.Errorf("cloudServerDefaultTitleFromHostname failed want '%s' got '%s'", want, got)
 	}


### PR DESCRIPTION
Longer titles are now supported by API.

refactor(server): rename cloudServerTitleLength to serverTitleLength and cloudServerDefaultTitleFromHostname to serverDefaultTitleFromHostname