### PR TITLE
feat(main): add support for debuggers like Delve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- Support for debuggers like delve
+- Support for debuggers like Delve
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Support for debuggers like delve
+
 ### Fixed
 
 - firewall: fix missing server_id when importing firewall resource

--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ After exiting the container, you can connect back to the container:
 docker start -ai <container ID here>
 ```
 
+### Debugging
+
+UpCloud provider can be run in debug mode using a debugger such as Delve.  
+For more information, see [Terraform docs](https://www.terraform.io/docs/extend/debugging.html#starting-a-provider-in-debug-mode)
+
 ### Consuming local provider with Terraform 0.12.0
 
 With the release of Terraform 0.13.0 the discovery of a locally built provider

--- a/main.go
+++ b/main.go
@@ -1,15 +1,38 @@
 package main // import "github.com/UpCloudLtd/terraform-provider-upcloud"
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/UpCloudLtd/terraform-provider-upcloud/upcloud"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+	var debugProviderAddr string
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.StringVar(&debugProviderAddr, "debug-provider-addr", "registry.terraform.io/upcloudltd/upcloud",
+		"use same provider address as used in your configs")
+
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
 			return upcloud.Provider()
 		},
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), debugProviderAddr, opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Start debug server if debug command-line flag is set.

Official documentations:  
https://www.terraform.io/docs/extend/debugging.html#enabling-debugging-in-a-provider

VS Code launch.json example:
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "UpCloud provider",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${workspaceRoot}",
            "envFile": "${env:HOME}/terraform/.env",
            "args": [
                "--debug",
            ]
        }
    ]
}
```
`envFile` is a file containing your UpCloud credentials.

If UpCloud source is set to `registry.upcloud.com/upcloud/upcloud` in configs then overwrite default provider address in args list:
```
"args": [
  "--debug",
   "--debug-provider-addr=registry.upcloud.com/upcloud/upcloud",
]
```