### PR TITLE
Fix/remove network servers field

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -52,7 +52,6 @@ resource "upcloud_router" "example_router" {
 
 ### Read-Only
 
-- **servers** (Set of Object) A list of attached servers (see [below for nested schema](#nestedatt--servers))
 - **type** (String) The network type
 
 <a id="nestedblock--ip_network"></a>
@@ -69,15 +68,6 @@ Optional:
 - **dhcp_default_route** (Boolean) Is the gateway the DHCP default route?
 - **dhcp_dns** (Set of String) The DNS servers given by DHCP
 - **gateway** (String) Gateway address given by DHCP
-
-
-<a id="nestedatt--servers"></a>
-### Nested Schema for `servers`
-
-Read-Only:
-
-- **id** (String)
-- **title** (String)
 
 ## Import
 

--- a/upcloud/resource_upcloud_network.go
+++ b/upcloud/resource_upcloud_network.go
@@ -110,25 +110,6 @@ func resourceUpCloudNetwork() *schema.Resource {
 				Description: "The UUID of a router",
 				Optional:    true,
 			},
-			"servers": {
-				Type:        schema.TypeSet,
-				Description: "A list of attached servers",
-				Computed:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:        schema.TypeString,
-							Description: "The UUID of the server",
-							Computed:    true,
-						},
-						"title": {
-							Type:        schema.TypeString,
-							Description: "The short description of the server",
-							Computed:    true,
-						},
-					},
-				},
-			},
 		},
 	}
 }


### PR DESCRIPTION
This PR removes the `servers` schema field for network resource. The field does not seem to be used anyway, attaching server to a network is done via servers network interfaces.