### PR TITLE
fix(firewall): Remove proto field's default value "tcp"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - firewall: fix missing server_id when importing firewall resource
 - firewall: change port types from int to string to avoid having zero values in state when importing rules with undefined port number(s).
+- firewall: remove proto field's default value "tcp" as this prevents settings optional fields value to null and update validator to accept empty string which corresponds to any protocol
 
 ### Changed
 

--- a/upcloud/resource_upcloud_firewall_rules.go
+++ b/upcloud/resource_upcloud_firewall_rules.go
@@ -63,8 +63,7 @@ func resourceUpCloudFirewallRules() *schema.Resource {
 							Description:  "The protocol this rule will be applied to",
 							Optional:     true,
 							ForceNew:     true,
-							Default:      "tcp",
-							ValidateFunc: validation.StringInSlice([]string{"tcp", "udp", "icmp"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"", "tcp", "udp", "icmp"}, false),
 						},
 						"icmp_type": {
 							Type:         schema.TypeString,

--- a/upcloud/resource_upcloud_firewall_rules_test.go
+++ b/upcloud/resource_upcloud_firewall_rules_test.go
@@ -29,7 +29,7 @@ func TestUpcloudFirewallRules_basic(t *testing.T) {
 			{
 				Config: testUpcloudFirewallRulesInstanceConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "firewall_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_rule.#", "2"),
 					testAccCheckFirewallRulesExists(resourceName, &firewallRules),
 					testAccCheckUpCloudFirewallRuleAttributes(&firewallRules, 0, "accept",
 						"Allow SSH from this network",
@@ -41,6 +41,20 @@ func TestUpcloudFirewallRules_basic(t *testing.T) {
 						"",
 						"22",
 						"22",
+						"192.168.1.1",
+						"192.168.1.255",
+						"",
+						""),
+					testAccCheckUpCloudFirewallRuleAttributes(&firewallRules, 1, "drop",
+						"Drop all connection from ip range",
+						"IPv4",
+						"",
+						"",
+						"in",
+						"",
+						"",
+						"",
+						"",
 						"192.168.1.1",
 						"192.168.1.255",
 						"",
@@ -65,7 +79,7 @@ func TestUpcloudFirewallRules_update(t *testing.T) {
 			{
 				Config: testUpcloudFirewallRulesInstanceConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "firewall_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_rule.#", "2"),
 					testAccCheckFirewallRulesExists(resourceName, &firewallRules),
 				),
 			},
@@ -253,6 +267,15 @@ func testUpcloudFirewallRulesInstanceConfig() string {
 			family = "IPv4"
 			icmp_type = ""
 			protocol = "tcp"
+			source_address_end = "192.168.1.255"
+			source_address_start = "192.168.1.1"
+		  }
+
+		  firewall_rule {
+			action = "drop"
+			comment = "Drop all connection from ip range"
+			direction = "in"
+			family = "IPv4"
 			source_address_end = "192.168.1.255"
 			source_address_start = "192.168.1.1"
 		  }


### PR DESCRIPTION
Remove proto field's default value "tcp" as this prevents settings optional fields value to null and update validator to accept empty string which corresponds to any protocol.