### PR TITLE
Use set instead of list for storing buckets in state

### DIFF
--- a/upcloud/resource_upcloud_objectstorage.go
+++ b/upcloud/resource_upcloud_objectstorage.go
@@ -79,7 +79,7 @@ func resourceUpCloudObjectStorage() *schema.Resource {
 				Computed: true,
 			},
 			bucketKey: {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -127,7 +127,7 @@ func resourceObjectStorageCreate(ctx context.Context, d *schema.ResourceData, m 
 			return diag.FromErr(err)
 		}
 
-		for _, bucketDetails := range v.([]interface{}) {
+		for _, bucketDetails := range v.(*schema.Set).List() {
 			details := bucketDetails.(map[string]interface{})
 
 			err = conn.MakeBucket(ctx, details["name"].(string), minio.MakeBucketOptions{})

--- a/upcloud/resource_upcloud_objectstorage.go
+++ b/upcloud/resource_upcloud_objectstorage.go
@@ -273,12 +273,12 @@ func getNewAndDeletedBucketNames(d *schema.ResourceData) ([]string, []string) {
 
 	before, after := d.GetChange(bucketKey)
 
-	for _, item := range before.([]interface{}) {
+	for _, item := range before.(*schema.Set).List() {
 		valueMap := item.(map[string]interface{})
 		beforeNames = append(beforeNames, valueMap["name"].(string))
 	}
 
-	for _, item := range after.([]interface{}) {
+	for _, item := range after.(*schema.Set).List() {
 		valueMap := item.(map[string]interface{})
 		afterNames = append(afterNames, valueMap["name"].(string))
 	}

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -238,6 +238,13 @@ func TestUpCloudObjectStorage_bucket_management(t *testing.T) {
 			{
 				Config: testUpCloudObjectStorageWithBucketsInstanceConfig(
 					expectedSize, objectStorageTestExpectedName2, objectStorageTestExpectedZone,
+					objectStorageTestExpectedKey, objectStorageTestExpectedSecret, expectedBucketName2, expectedBucketName1,
+				),
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testUpCloudObjectStorageWithBucketsInstanceConfig(
+					expectedSize, objectStorageTestExpectedName2, objectStorageTestExpectedZone,
 					objectStorageTestExpectedKey, objectStorageTestExpectedSecret, expectedBucketName1,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
Currently buckets are created in the order of configuration. However they are stored in the order what the UpCloud API returns. Since users should be able to change the order of the configuration, and the resources are not dependent on each other, we should store the buckets into sets instead of lists.

Fixes issue #181.