### PR TITLE
fix(dbaas): increase dns retry interval

### DIFF
--- a/upcloud/resource_upcloud_managed_database.go
+++ b/upcloud/resource_upcloud_managed_database.go
@@ -760,7 +760,7 @@ func waitServiceNameToPropagate(ctx context.Context, name string) (err error) {
 			return nil
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 	return errors.New("max retries reached while waiting for service name to propagate")
 }


### PR DESCRIPTION
Increase dns retry interval to match db.upclouddatabases.com SOA record.