### PR TITLE
fix(server): subaccount tagging error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - firewall: change port types from int to string to avoid having zero values in state when importing rules with undefined port number(s).
 - firewall: remove proto field's default value "tcp" as this prevents settings optional fields value to null and update validator to accept empty string which corresponds to any protocol
 - object storage: fix issue where order of storage buckets in an object storage resource would incorrectly trigger changes
+- server: return more descriptive error message if subaccount tries to edit server tags
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/terraform-provider-upcloud
 go 1.16
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.2
+	github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.3
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.2 h1:cBavAg71YonD59yI7JPnPrwu79wqT8RhfChWiS0+WoA=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.2/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.3 h1:4llTGaEFtbWoqb9Yld/ywjqAGoKNB/frzmncx8evyKA=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.1.3/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/service"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -117,4 +118,16 @@ func newUpCloudServiceConnection(username, password string, httpClient *http.Cli
 	client.SetTimeout(upcloudAPITimeout)
 
 	return service.New(client)
+}
+
+func isProviderAccountSubaccount(s *service.Service) (bool, error) {
+	account, err := s.GetAccount()
+	if err != nil {
+		return false, err
+	}
+	a, err := s.GetAccountDetails(&request.GetAccountDetailsRequest{Username: account.UserName})
+	if err != nil {
+		return false, err
+	}
+	return a.IsSubaccount(), nil
 }


### PR DESCRIPTION
Return more descriptive error message if subaccount tries to
edit server tags.

Update Go API dependency from v4.1.2 to v4.1.3 to get access to
new account functions.