### PR TITLE
fix(storage): fix missing backup_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- storage: fix missing backup_rule when importing resource
+
 ## [2.1.4] - 2022-01-18
 
 ### Added

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -18,6 +18,7 @@ func BackupRuleSchema() *schema.Schema {
 		Type:     schema.TypeList,
 		MaxItems: 1,
 		Optional: true,
+		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"interval": {

--- a/upcloud/resource_upcloud_storage.go
+++ b/upcloud/resource_upcloud_storage.go
@@ -372,23 +372,17 @@ func resourceUpCloudStorageRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	// This means the changes to the backup_rule will only be tracked if the user has
-	// backup_rule block in their tf config (or just removed it from there). This is
-	// to avoid conflicting backup rules when using simple_backups with server that storage
-	// is attached to
-	if _, ok := d.GetOk("backup_rule"); ok {
-		if storage.BackupRule != nil && storage.BackupRule.Retention > 0 {
-			backupRule := []interface{}{
-				map[string]interface{}{
-					"interval":  storage.BackupRule.Interval,
-					"time":      storage.BackupRule.Time,
-					"retention": storage.BackupRule.Retention,
-				},
-			}
+	if storage.BackupRule != nil && storage.BackupRule.Retention > 0 {
+		backupRule := []interface{}{
+			map[string]interface{}{
+				"interval":  storage.BackupRule.Interval,
+				"time":      storage.BackupRule.Time,
+				"retention": storage.BackupRule.Retention,
+			},
+		}
 
-			if err := d.Set("backup_rule", backupRule); err != nil {
-				return diag.FromErr(err)
-			}
+		if err := d.Set("backup_rule", backupRule); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/upcloud/resource_upcloud_storage_test.go
+++ b/upcloud/resource_upcloud_storage_test.go
@@ -188,18 +188,13 @@ func TestAccUpCloudStorage_import(t *testing.T) {
 	var providers []*schema.Provider
 	var storageDetails upcloud.StorageDetails
 
-	expectedSize := "10"
-	expectedTier := StorageTier
-	expectedTitle := storageDescription
-	expectedZone := "fi-hel1"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckStorageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testUpcloudStorageInstanceConfig(expectedSize, expectedTier, expectedTitle, expectedZone),
+				Config: testUpcloudStorageInstanceConfigWithBackupRule("daily", "0700", "7"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageExists("upcloud_storage.my_storage", &storageDetails),
 				),


### PR DESCRIPTION
Storage resource ignored backup_rule if it wasn't defined in config.
This resulted in inconsistent state when importing storage and if simple backup was enabled in the server config.