### PR TITLE
Fix build-time variable injection for release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     - -trimpath
   ldflags:
     - -s -w
-    - -X {{.Env.GO_MODULE_NAME}}/internal/globals.Version={{.Version}}
+    - -X {{.Env.GO_MODULE_NAME}}/internal/config.Version={{.Version}}
   goos:
     - freebsd
     - windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - storage: fix missing backup_rule when importing resource
+- provider: fix user-agent for release builds
 
 ## [2.1.4] - 2022-01-18
 


### PR DESCRIPTION
Build-time variable injection was modified on #164 and #165 where the variable was moved from `globals` package to `config`. Since then the release pipeline has still been referencing the old package. Due to this configuration issue the version information has not made it into the release builds. API client uses this information for initialising the HTTP user agent correctly.