### PR TITLE
fix(server): missing template id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - storage: fix missing backup_rule when importing resource
 - provider: fix user-agent for release builds
+- server: fix missing template id if resource creation fails on tag errors
 
 ## [2.1.4] - 2022-01-18
 


### PR DESCRIPTION
Fix missing template id if resource creation fails on tag errors.
Missing id will prevent deleting the resource.