### PR TITLE
Fix/importing managed db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - docs: set provider username and password as required arguments
 - provider: return underlying error from initial login check instead of custom error
 - provider: fix dangling resource references by removing a binding to an remote object if it no longer exists
+- provider: fix runtime error when importing managed database
+
 
 ## [2.1.5] - 2022-01-27
 

--- a/upcloud/resource_upcloud_managed_database.go
+++ b/upcloud/resource_upcloud_managed_database.go
@@ -487,8 +487,7 @@ func copyManagedDatabaseDetailsToResourceData(d *schema.ResourceData, details *u
 		}
 
 		newProps, err := buildManagedDatabasePropertiesResourceDataFromAPIProperties(props,
-			upcloudschema.ManagedDatabaseServicePropertiesSchema(
-				upcloud.ManagedDatabaseServiceType(details.Type)))
+			upcloudschema.ManagedDatabaseServicePropertiesSchema(details.Type))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/upcloud/resource_upcloud_managed_database.go
+++ b/upcloud/resource_upcloud_managed_database.go
@@ -485,9 +485,10 @@ func copyManagedDatabaseDetailsToResourceData(d *schema.ResourceData, details *u
 		for k, v := range details.Properties {
 			props[string(k)] = v
 		}
+
 		newProps, err := buildManagedDatabasePropertiesResourceDataFromAPIProperties(props,
 			upcloudschema.ManagedDatabaseServicePropertiesSchema(
-				upcloud.ManagedDatabaseServiceType(d.Get("type").(string))))
+				upcloud.ManagedDatabaseServiceType(details.Type)))
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
Fix a runtime error when importing managed db.

The error was caused by the fact that `type` is set by provider during creation. So when we import the db, `d.Get("type")` does not actually return anything, which ten causes some problems down the line