### PR TITLE
Feat/object storage import temp creds

### DIFF
--- a/upcloud/resource_upcloud_objectstorage.go
+++ b/upcloud/resource_upcloud_objectstorage.go
@@ -315,6 +315,10 @@ func copyObjectStorageDetails(objectDetails *upcloud.ObjectStorageDetails, d *sc
 		_ = d.Set("secret_key", "")
 	}
 
+	// This is an undocumented feature, can be changed or removed at any time without any announcements
+	// It allows you to also specify session token in env variables, which will be then passed to minio client
+	// along with access and secret key. This allows you to use temp credentials to read buckets list and such.
+	// This is only intended for import.
 	token := getToken(d)
 
 	conn, err := getBucketConnection(objectDetails.URL, accessKey, secretKey, token)

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -486,7 +486,7 @@ func getMinioConnection(state *terraform.State, accessKey, secretKey string) (*m
 		return nil, fmt.Errorf("could not find resources")
 	}
 
-	return getBucketConnection(resources.Primary.Attributes["url"], accessKey, secretKey)
+	return getBucketConnection(resources.Primary.Attributes["url"], accessKey, secretKey, "")
 }
 
 func verifyBucketExists(accessKey, secretKey, name, bucketName string) resource.TestCheckFunc {


### PR DESCRIPTION
This PR adds an option to pass session token in env vars when importing object storage.