### PR TITLE
Chore/update go sdk 4.4.2

### DIFF
--- a/docs/resources/loadbalancer_frontend_rule.md
+++ b/docs/resources/loadbalancer_frontend_rule.md
@@ -134,6 +134,7 @@ Required:
 Optional:
 
 - **body_size** (Block List, Max: 100) Matches by HTTP request body size. (see [below for nested schema](#nestedblock--matchers--body_size))
+- **body_size_range** (Block List, Max: 100) Matches by range of HTTP request body sizes (see [below for nested schema](#nestedblock--matchers--body_size_range))
 - **cookie** (Block List, Max: 100) Matches by HTTP cookie value. Cookie name must be provided. (see [below for nested schema](#nestedblock--matchers--cookie))
 - **header** (Block List, Max: 100) Matches by HTTP header value. Header name must be provided. (see [below for nested schema](#nestedblock--matchers--header))
 - **host** (Block List, Max: 100) Matches by hostname. Header extracted from HTTP Headers or from TLS certificate in case of secured connection. (see [below for nested schema](#nestedblock--matchers--host))
@@ -142,6 +143,7 @@ Optional:
 - **path** (Block List, Max: 100) Matches by URL path. (see [below for nested schema](#nestedblock--matchers--path))
 - **src_ip** (Block List, Max: 100) Matches by source IP address. (see [below for nested schema](#nestedblock--matchers--src_ip))
 - **src_port** (Block List, Max: 100) Matches by source port number. (see [below for nested schema](#nestedblock--matchers--src_port))
+- **src_port_range** (Block List, Max: 100) Matches by range of source port numbers (see [below for nested schema](#nestedblock--matchers--src_port_range))
 - **url** (Block List, Max: 100) Matches by URL without schema, e.g. `example.com/dashboard`. (see [below for nested schema](#nestedblock--matchers--url))
 - **url_param** (Block List, Max: 100) Matches by URL query parameter value. Query parameter name must be provided (see [below for nested schema](#nestedblock--matchers--url_param))
 - **url_query** (Block List, Max: 100) Matches by URL query string. (see [below for nested schema](#nestedblock--matchers--url_query))
@@ -154,7 +156,11 @@ Required:
 - **method** (String) Match method (`equal`, `greater`, `greater_or_equal`, `less`, `less_or_equal`).
 - **value** (Number) Integer value.
 
-Optional:
+
+<a id="nestedblock--matchers--body_size_range"></a>
+### Nested Schema for `matchers.body_size_range`
+
+Required:
 
 - **range_end** (Number) Integer value.
 - **range_start** (Number) Integer value.
@@ -243,7 +249,11 @@ Required:
 - **method** (String) Match method (`equal`, `greater`, `greater_or_equal`, `less`, `less_or_equal`).
 - **value** (Number) Integer value.
 
-Optional:
+
+<a id="nestedblock--matchers--src_port_range"></a>
+### Nested Schema for `matchers.src_port_range`
+
+Required:
 
 - **range_end** (Number) Integer value.
 - **range_start** (Number) Integer value.

--- a/docs/resources/loadbalancer_resolver.md
+++ b/docs/resources/loadbalancer_resolver.md
@@ -57,6 +57,8 @@ resource "upcloud_loadbalancer_resolver" "lb_resolver_1" {
 - **cache_valid** (Number) Time in seconds to cache valid results.
 - **loadbalancer** (String) ID of the load balancer to which the resolver is connected.
 - **name** (String) The name of the resolver must be unique within the service.
+- **nameservers** (List of String) List of nameserver IP addresses. Nameserver can reside in public internet or in customer private network. 
+				Port is optional, if missing then default 53 will be used.
 - **retries** (Number) Number of retries on failure.
 - **timeout** (Number) Timeout for the query in seconds.
 - **timeout_retry** (Number) Timeout for the query retries in seconds.
@@ -64,7 +66,5 @@ resource "upcloud_loadbalancer_resolver" "lb_resolver_1" {
 ### Optional
 
 - **id** (String) The ID of this resource.
-- **nameservers** (List of String) List of nameserver IP addresses. Nameserver can reside in public internet or in customer private network. 
-				Port is optional, if missing then default 53 will be used.
 
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/terraform-provider-upcloud
 go 1.16
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.1
+	github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,6 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.1 h1:hLBkLmG8QAJZYSKfYfDFDTk6TtiS18nMRONZSSq6i1w=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.1/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2-0.20220411053716-11476cbfa24a h1:C8envLXuuvtq4KRfDKKZFNHFOuznmPc7EQTSqiqhIz4=
-github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2-0.20220411053716-11476cbfa24a/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
 github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2 h1:fc4y1czqxf1PG0dJ0ozfoWj1CkiZvSdG2WKy3tdrmsM=
 github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.1 h1:hLBkLmG8QAJZYSKfYfDFDTk6TtiS18nMRONZSSq6i1w=
 github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.1/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2-0.20220411053716-11476cbfa24a h1:C8envLXuuvtq4KRfDKKZFNHFOuznmPc7EQTSqiqhIz4=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2-0.20220411053716-11476cbfa24a/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2 h1:fc4y1czqxf1PG0dJ0ozfoWj1CkiZvSdG2WKy3tdrmsM=
+github.com/UpCloudLtd/upcloud-go-api/v4 v4.4.2/go.mod h1:yGgbryc2wCR6fzfRCMnH6ZrjWPfZjKCWaJDnp4IameY=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/internal/service/loadbalancer/resolver.go
+++ b/internal/service/loadbalancer/resolver.go
@@ -169,7 +169,7 @@ func resourceResolverUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if err := unmarshalID(d.Id(), &serviceID, &name); err != nil {
 		return diag.FromErr(err)
 	}
-	rs, err := svc.ModifyLoadBalancerResolver(&request.ModifyLoadBalancerRevolverRequest{
+	rs, err := svc.ModifyLoadBalancerResolver(&request.ModifyLoadBalancerResolverRequest{
 		ServiceUUID: serviceID,
 		Name:        name,
 		Resolver: request.LoadBalancerResolver{


### PR DESCRIPTION
Update to go SDK 4.4.2
Fixed resolver spelling (related to SDK update)
Update docs (because we missed some updates in one of the past additions)