### PR TITLE
Refactor server tags handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- server: Remove all tags when tags change into an empty value
+- server: Delete unused tags created with server resource on server delete
+- server: Improve tags validation: check for case-insensitive duplicates, supress diff when only order of tags changes, print warning when trying to create existing tag with different letter casing
+
 ## [2.4.0] - 2022-04-12
 
 ### Added

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -56,6 +56,12 @@ terraform {
 
 **Testing**
 
+To lint the providers source-code, run `golangci-lint run`. See [golangci-lint docs](https://golangci-lint.run/usage/install/) for installation instructions.
+
+```sh
+golangci-lint run
+```
+
 In order to test the provider, you can simply run `make test`.
 
 ```sh

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -698,7 +698,7 @@ func resourceUpCloudServerUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	if _, ok := d.GetOk("tags"); ok && tagsHasChange {
+	if tagsHasChange {
 		oldTags, newTags := d.GetChange("tags")
 		if err := server.UpdateServerTags(
 			client, d.Id(),

--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -858,7 +858,11 @@ func resourceUpCloudServerDelete(ctx context.Context, d *schema.ResourceData, me
 
 	// Delete tags that are not used by any other servers
 	if err := server.RemoveServerTags(client, d.Id(), utils.ExpandStrings(d.Get("tags"))); err != nil {
-		return diag.FromErr(err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "failed to delete tags that will be unused after server deletion",
+			Detail:   err.Error(),
+		})
 	}
 
 	// Delete server


### PR DESCRIPTION
- Ignore the order of tags in server tests: If tags are already defined by other servers, they might appear in different order than the one specified in tag server API request.
- Remove all tags when tags change into an empty value.
- Delete unused tags created with server resource on server delete 
- Improve tag handling on server create, update, and delete:
    - Remove extra TagServer call.
    - Return and print warning if trying to create existing tag with different letter casing. After this, we should not get TAG_EXISTS errros, which previously resulted to incorrect tags state.
    - Only add and delete tags if necessary on server update.
- Validate that tags do no contain duplicates and supress diff when only order of the tags changes