### PR TITLE
Adds password delivery methods to documentation

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -105,7 +105,7 @@ Optional:
 
 - **create_password** (Boolean) Indicates a password should be create to allow access
 - **keys** (List of String) A list of ssh keys to access the server
-- **password_delivery** (String) The delivery method for the server’s root password
+- **password_delivery** (String) The delivery method for the server's root password (one of `none`, `email` or `sms`)
 - **user** (String) Username to be create to access the server
 
 

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -330,7 +330,7 @@ func ResourceServer() *schema.Resource {
 							Default:     false,
 						},
 						"password_delivery": {
-							Description:  "The delivery method for the server’s root password",
+							Description:  "The delivery method for the server's root password (one of `none`, `email` or `sms`)",
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "none",


### PR DESCRIPTION
I had to check source code for possible values for password_delivery property. These could be added to documentation.