### PR TITLE
Add action for auto-generating docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - test-docs-generator # for testing
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.17"
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_wrapper: false
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+    - name: Generate documentation
+      run: |
+        terraform version
+        make docs
+    - name: Create PR for docs update
+      uses: peter-evans/create-pull-request@v4
+      with:
+        add-paths: docs/
+        branch: chore/update-docs
+        commit-message: "chore(docs): update documentation"
+        committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+        reviewers: ${{ github.actor }}
+        title: Update documentation
+        body: "This is an automatically created PR. Changes were created by running `make docs` on ${{ github.sha }}."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,17 @@
 name: Documentation
 
 on:
-  push:
+  pull_request:
+    types:
+    - closed
     branches:
-      - main
-      - test-docs-generator # for testing
+    - main
+    - test-docs-generator # for testing
 
 jobs:
   update:
     name: Update
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
@@ -21,8 +24,6 @@ jobs:
         terraform_wrapper: false
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
     - name: Generate documentation
       run: |
         terraform version
@@ -32,8 +33,9 @@ jobs:
       with:
         add-paths: docs/
         branch: chore/update-docs
-        commit-message: "chore(docs): update documentation"
+        commit-message: "chore(docs): update documentation for #${{ github.event.number }}"
         committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
         reviewers: ${{ github.actor }}
         title: Update documentation
-        body: "This is an automatically created PR. Changes were created by running `make docs` on ${{ github.sha }}."
+        body: "This is an automatically created PR. Changes were created by running `make docs` after merging #${{ github.event.number }} (${{ github.sha }})."
+        base: ${{ github.event.pull_request.base.ref }}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -96,7 +96,9 @@ In order to view the documentation change rendering visite
 
 ## Generating documentation
 
-The documentation in [docs](./docs/) directory is generated with [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs). To install the tool and build the docs, run `make docs`.
+The documentation in [docs](./docs/) directory is generated with [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs). This is done automatically when changes are merged to the `main` branch. If there are documentation changes, actions will create a new pull request for documentation changes. Review and merge this pull-request.
+
+To generate the docs locally, run `make docs`. This installs the tool and builds the docs.
 
 ```sh
 make docs


### PR DESCRIPTION
Testing results (1st commit):

- See #289 for test PR that adds extra text to `docs/` that will be removed as it is not found from templates or source-code.
- See #290 for PR created by this new action. (Edited PR body manually to test if GitHub changes Commit ID automatically into a link)

Testing result (2nd commit):

- #292
- #293