### PR TITLE
fix: set credentials as optional inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - dbaas: updated property descriptions
 - structured logging with `tflog`
 - storage: update maximum storage size from 2048 to 4096 gigabytes
+- provider: changed `username` and `password` into optional parameters. This does not change how these parameters are used: providing these values in the provider block has already been optional, if credentials were defined as environment variables.
 
 ## [2.5.0] - 2022-06-20
 

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -35,15 +35,15 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"username": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("UPCLOUD_USERNAME", nil),
-				Description: "UpCloud username with API access",
+				Description: "UpCloud username with API access. Can also be configured using the `UPCLOUD_USERNAME` environment variable.",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("UPCLOUD_PASSWORD", nil),
-				Description: "Password for UpCloud API user",
+				Description: "Password for UpCloud API user. Can also be configured using the `UPCLOUD_PASSWORD` environment variable.",
 			},
 			"retry_wait_min_sec": {
 				Type:        schema.TypeInt,


### PR DESCRIPTION
This does not change how these inputs are used: providing these values in the provider block has already been optional if credentials were defined as environment variables.