### PR TITLE
ci(terraform): concurrency group for workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,6 +6,10 @@ on:
       - upcloud/**
       - internal/**
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

This allows us to limit the Terraform acceptance tests to 1 concurrent workflow at a time.