### PR TITLE
fix(makefile): list current package in workspace

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,10 +2,10 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 
-MODULE   = $(shell env GO111MODULE=on go list -m)
-GIT_VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
+PACKAGE=$(shell env GO111MODULE=on go list)
+GIT_VERSION?=$(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
 			cat $(CURDIR)/.version 2> /dev/null || echo v0)
-VERSION = $(shell echo $(GIT_VERSION) | sed 's/^v//' | sed 's/-.*//')
+VERSION=$(shell echo $(GIT_VERSION) | sed 's/^v//' | sed 's/-.*//')
 
 PROVIDER_HOSTNAME=registry.upcloud.com
 PROVIDER_NAMESPACE=upcloud
@@ -13,7 +13,7 @@ PROVIDER_TYPE=upcloud
 PROVIDER_TARGET=$(shell go env GOOS)_$(shell go env GOARCH)
 PROVIDER_PATH=~/.terraform.d/plugins/$(PROVIDER_HOSTNAME)/$(PROVIDER_NAMESPACE)/$(PROVIDER_TYPE)/$(VERSION)/$(PROVIDER_TARGET)
 
-TOOLS_DIR := $(CURDIR)/.ci/bin
+TOOLS_DIR:=$(CURDIR)/.ci/bin
 
 default: build
 
@@ -21,7 +21,7 @@ build: fmtcheck
 	@mkdir -p $(PROVIDER_PATH)
 	go build \
 		-tags release \
-		-ldflags '-X $(MODULE)/internal/config.Version=$(GIT_VERSION)' \
+		-ldflags '-X $(PACKAGE)/internal/config.Version=$(GIT_VERSION)' \
 		-o $(PROVIDER_PATH)/terraform-provider-$(PROVIDER_NAMESPACE)_v$(VERSION)
 
 build_0_12: fmtcheck


### PR DESCRIPTION
Fixes a `GNUmakefile` issue when using go workspace and multiple modules are stored in `${MODULE}`.

Before:
```shell
make
==> Checking that code complies with gofmt requirements...
go build \
	-tags release \
	-ldflags '-X github.com/UpCloudLtd/progress github.com/UpCloudLtd/terraform-provider-upcloud github.com/UpCloudLtd/terraform-provider-upcloud/tools github.com/UpCloudLtd/upcloud-cli github.com/UpCloudLtd/upcloud-go-api/v4/internal/config.Version=v2.5.0-24-g44a59373-dirty' \
	-o ~/.terraform.d/plugins/registry.upcloud.com/upcloud/upcloud/2.5.0/linux_amd64/terraform-provider-upcloud_v2.5.0
# github.com/UpCloudLtd/terraform-provider-upcloud
/usr/lib/go-1.18/pkg/tool/linux_amd64/link: -X flag requires argument of the form importpath.name=value
make: *** [GNUmakefile:22: build] Error 2
```

After:
```
make
==> Checking that code complies with gofmt requirements...
go build \
	-tags release \
	-ldflags '-X github.com/UpCloudLtd/terraform-provider-upcloud/internal/config.Version=v2.5.0-24-g44a59373-dirty' \
	-o ~/.terraform.d/plugins/registry.upcloud.com/upcloud/upcloud/2.5.0/linux_amd64/terraform-provider-upcloud_v2.5.0
```