### PR TITLE
docs(server): add `upctl` command for listing templates

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -145,7 +145,7 @@ Optional:
 
 Required:
 
-- `storage` (String) A valid storage UUID or template name
+- `storage` (String) A valid storage UUID or template name. You can list available public templates with `upctl storage list --public --template` and available private templates with `upctl storage list --template`.
 
 Optional:
 

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -286,7 +286,7 @@ func ResourceServer() *schema.Resource {
 							ValidateFunc: validation.StringLenBetween(0, 64),
 						},
 						"storage": {
-							Description: "A valid storage UUID or template name",
+							Description: "A valid storage UUID or template name. You can list available public templates with `upctl storage list --public --template` and available private templates with `upctl storage list --template`.",
 							Type:        schema.TypeString,
 							ForceNew:    true,
 							Required:    true,


### PR DESCRIPTION
This PR adds examples on how to list available public and private templates.