### PR TITLE
fix(gateway): wait for running state when creating the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - lbaas: add `labels` support
 - server, server group: add validation for `labels` keys and values
 
+### Fixed
+- gateway: wait for gateway to reach running state during resource create
+
 ## [2.9.0] - 2023-03-13
 
 ### Added


### PR DESCRIPTION
This allows using `depends_on` to wait for gateway to be running if there are servers or other resources that need internet connection through the gateway right after creation (e.g. servers user-data script needs access to internet).