### PR TITLE
feat(kubernetes): new `plan` field to cluster resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.52.2
     hooks:
       - id: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- kubernetes: plan field to `upcloud_kubernetes_cluster` resource
+
+### Changed
+- update upcloud-go-api to v6.1.0
+
 ## [2.9.1] - 2023-04-03
 
 ### Added

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -47,6 +47,10 @@ resource "upcloud_kubernetes_cluster" "example" {
 - `network` (String) Network ID for the cluster to run in.
 - `zone` (String) Zone in which the Kubernetes cluster will be hosted, e.g. `de-fra1`.
 
+### Optional
+
+- `plan` (String) The pricing plan used for the cluster. Default plan is `development`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/UpCloudLtd/terraform-provider-upcloud
 go 1.18
 
 require (
-	github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0
+	github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0 h1:q4FYAC9/4hmkTop30XMOBMQfgj5iakTQEFEgc3T6dqE=
-github.com/UpCloudLtd/upcloud-go-api/v6 v6.0.0/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.0 h1:qSndE6VOrzp2JFGOmaWf4pZJjZA5a9L4iBr+/rKGnxM=
+github.com/UpCloudLtd/upcloud-go-api/v6 v6.1.0/go.mod h1:9y8kZ4o4jCagqLfexcnITY8uc/g4+uc18wbnMsDbQJI=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -58,6 +58,13 @@ func ResourceCluster() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"plan": {
+				Description: "The pricing plan used for the cluster. Default plan is `development`.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "development",
+			},
 			"network": {
 				Description: networkDescription,
 				Type:        schema.TypeString,
@@ -93,6 +100,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Name:    d.Get("name").(string),
 		Network: d.Get("network").(string),
 		Zone:    d.Get("zone").(string),
+		Plan:    d.Get("plan").(string),
 	}
 
 	c, err := svc.CreateKubernetesCluster(ctx, req)
@@ -154,6 +162,10 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 func setClusterResourceData(d *schema.ResourceData, c *upcloud.KubernetesCluster) (diags diag.Diagnostics) {
 	if err := d.Set("name", c.Name); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("plan", c.Plan); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
- new `plan` field to `upcloud_kubernetes_cluster` resource
- update golangci-lint to v1.52.2
- update upcloud-go-api to v6.1.0