### PR TITLE
chore(docs): update docs for k8s resources

### DIFF
--- a/internal/service/kubernetes/data_sources.go
+++ b/internal/service/kubernetes/data_sources.go
@@ -51,7 +51,7 @@ type kubeconfigUserData struct {
 
 func DataSourceCluster() *schema.Resource {
 	return &schema.Resource{
-		Description: "Kubernetes cluster details. Please refer to https://www.terraform.io/language/state/sensitive-data to keep the credential data as safe as possible. NOTE: this is an experimental feature in an alpha phase, the resource definition will change in the future.",
+		Description: "Managed Kubernetes cluster details. Please refer to https://www.terraform.io/language/state/sensitive-data to keep the credential data as safe as possible.",
 		ReadContext: dataSourceClusterRead,
 		Schema: map[string]*schema.Schema{
 			"client_certificate": {

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -37,7 +37,7 @@ const (
 
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Kubernetes cluster. NOTE: this is an experimental feature in development phase, the resource definition will change in the future.",
+		Description:   "This resource represents a Managed Kubernetes cluster.",
 		CreateContext: resourceClusterCreate,
 		ReadContext:   resourceClusterRead,
 		DeleteContext: resourceClusterDelete,

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -15,7 +15,7 @@ import (
 
 func ResourceNodeGroup() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Kubernetes node group. NOTE: this is an experimental feature in development phase, the resource definition might change in the future.",
+		Description:   "This resource represents a node group in a Managed Kubernetes cluster.",
 		CreateContext: resourceNodeGroupCreate,
 		ReadContext:   resourceNodeGroupRead,
 		DeleteContext: resourceNodeGroupDelete,


### PR DESCRIPTION
Update documentation for Managed Kubernetes related resources and datasources:

Resources affected:

- `upcloud_kubernetes_cluster`
- `upcloud_kubernetes_node_group`

Data sources affected:

- `upcloud_kubernetes_cluster`

No longer experimental.