### PR TITLE
chore(test): enable k8s acceptance tests by default

### DIFF
--- a/upcloud/resource_upcloud_kubernetes_test.go
+++ b/upcloud/resource_upcloud_kubernetes_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccUpcloudKubernetes(t *testing.T) {
-
 	testDataS1 := utils.ReadTestDataFile(t, "testdata/upcloud_kubernetes/kubernetes_s1.tf")
 	testDataS2 := utils.ReadTestDataFile(t, "testdata/upcloud_kubernetes/kubernetes_s2.tf")
 

--- a/upcloud/resource_upcloud_kubernetes_test.go
+++ b/upcloud/resource_upcloud_kubernetes_test.go
@@ -1,7 +1,6 @@
 package upcloud
 
 import (
-	"os"
 	"testing"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
@@ -10,10 +9,6 @@ import (
 )
 
 func TestAccUpcloudKubernetes(t *testing.T) {
-	if os.Getenv("TF_ACC_K8S") == "" {
-		// TODO: remove this check when API is publicly available
-		t.Skip("define TF_ACC_K8S env to run experimental Kubernetes test")
-	}
 
 	testDataS1 := utils.ReadTestDataFile(t, "testdata/upcloud_kubernetes/kubernetes_s1.tf")
 	testDataS2 := utils.ReadTestDataFile(t, "testdata/upcloud_kubernetes/kubernetes_s2.tf")

--- a/upcloud/testdata/upcloud_kubernetes/kubernetes_s1.tf
+++ b/upcloud/testdata/upcloud_kubernetes/kubernetes_s1.tf
@@ -16,6 +16,10 @@ resource "upcloud_network" "main" {
     dhcp    = true
     family  = "IPv4"
   }
+  # UpCloud Kubernetes Service will add a router to this network to ensure cluster networking is working as intended.
+  lifecycle {
+    ignore_changes = [router]
+  }
 }
 
 resource "upcloud_kubernetes_cluster" "main" {

--- a/upcloud/testdata/upcloud_kubernetes/kubernetes_s2.tf
+++ b/upcloud/testdata/upcloud_kubernetes/kubernetes_s2.tf
@@ -16,6 +16,10 @@ resource "upcloud_network" "main" {
     dhcp    = true
     family  = "IPv4"
   }
+  # UpCloud Kubernetes Service will add a router to this network to ensure cluster networking is working as intended.
+  lifecycle {
+    ignore_changes = [router]
+  }
 }
 
 resource "upcloud_kubernetes_cluster" "main" {


### PR DESCRIPTION
Enable k8s acceptance tests by default and remove env variable check.

Added `ignore_changes` workaround for `upcloud_network` for both the tests. Detailed explanation in [uks-instructions/KNOWN_ISSUES.md](https://github.com/UpCloudLtd/uks-instructions/blob/5e18ad55ee636606560b89439038f41c33464e5b/KNOWN_ISSUES.md#terraform).