### PR TITLE
chore(docs): add help text to list db and k8s plans

### DIFF
--- a/internal/service/database/database_common.go
+++ b/internal/service/database/database_common.go
@@ -44,7 +44,7 @@ func schemaDatabaseCommon() map[string]*schema.Schema {
 		},
 		"node_states": schemaDatabaseNodeStates(),
 		"plan": {
-			Description: "Service plan to use. This determines how much resources the instance will have",
+			Description: "Service plan to use. This determines how much resources the instance will have. You can list available plans with `upctl database plans <type>`.",
 			Type:        schema.TypeString,
 			Required:    true,
 		},

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -59,7 +59,7 @@ func ResourceCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"plan": {
-				Description: "The pricing plan used for the cluster. Default plan is `development`.",
+				Description: "The pricing plan used for the cluster. Default plan is `development`. You can list available plans with `upctl kubernetes plans`.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -44,7 +44,7 @@ func ResourceNodeGroup() *schema.Resource {
 				ForceNew:         true,
 			},
 			"plan": {
-				Description: "The pricing plan used for the node group. You can list available plans with `upctl server plans`",
+				Description: "The server plan used for the node group. You can list available plans with `upctl server plans`",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,


### PR DESCRIPTION
Align help text on how different resources handle `plan` and `zone` attributes.