### PR TITLE
chore(test): align Redis properties test with the rest

### DIFF
--- a/upcloud/testdata/upcloud_managed_database/redis_properties_s1.tf
+++ b/upcloud/testdata/upcloud_managed_database/redis_properties_s1.tf
@@ -1,5 +1,5 @@
 resource "upcloud_managed_database_redis" "redis_properties" {
-  name = "redis-properties-test"
+  name = "tf-redis-properties-test"
   plan = "1x1xCPU-2GB"
   zone = "fi-hel2"
   properties {

--- a/upcloud/testdata/upcloud_managed_database/redis_properties_s2.tf
+++ b/upcloud/testdata/upcloud_managed_database/redis_properties_s2.tf
@@ -1,5 +1,5 @@
 resource "upcloud_managed_database_redis" "redis_properties" {
-  name = "redis-properties-test"
+  name = "tf-redis-properties-test"
   plan = "1x1xCPU-2GB"
   zone = "fi-hel2"
   properties {


### PR DESCRIPTION
Helps janitor work in case of dangling resources after failed runs :)