### PR TITLE
chore: use Go 1.20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,16 +14,16 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.18"
+          go-version-file: 'go.mod'
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Generate documentation
         run: |
           terraform version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53.2

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,13 +15,13 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - name: "Setup Go"
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.18.x"
-
       - name: "Checkout source code"
         uses: actions/checkout@v3
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
 
       - name: "Run unit tests"
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
-    - deadcode
     # - depguard
     - dogsled
     - errcheck
@@ -31,12 +30,10 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/terraform-provider-upcloud
 
-go 1.18
+go 1.20
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/v6 v6.3.2


### PR DESCRIPTION
- Use Go 1.20 in `go.mod` and CI actions
- Remove deprecated linters