### PR TITLE
chore(kubernetes): remove node group size validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - gateway: add read-only `addresses` field
 
+### Changed
+- kubernetes: remove node group maximum value validation. The maximum number of nodes (in the cluster) is determined by the cluster plan and the validation is done on the API side.
+
 ## [2.12.0] - 2023-07-21
 
 ### Added

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -31,9 +31,10 @@ func ResourceNodeGroup() *schema.Resource {
 				ForceNew:    true,
 			},
 			"node_count": {
-				Description: "Amount of nodes to provision in the node group.",
-				Type:        schema.TypeInt,
-				Required:    true,
+				Description:  "Amount of nodes to provision in the node group.",
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntAtLeast(0),
+				Required:     true,
 			},
 			"name": {
 				Description:      "The name of the node group. Needs to be unique within a cluster.",

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -31,10 +31,9 @@ func ResourceNodeGroup() *schema.Resource {
 				ForceNew:    true,
 			},
 			"node_count": {
-				Description:      "Amount of nodes to provision in the node group.",
-				Type:             schema.TypeInt,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 16)),
-				Required:         true,
+				Description: "Amount of nodes to provision in the node group.",
+				Type:        schema.TypeInt,
+				Required:    true,
 			},
 			"name": {
 				Description:      "The name of the node group. Needs to be unique within a cluster.",


### PR DESCRIPTION
Remove node group size validation from the provider and rely on API instead. This is a leftover from earlier test phases.