### PR TITLE
Enhance Timeout Configuration for UpCloud Provider in Terraform

### DIFF
--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -67,7 +67,7 @@ func Provider() *schema.Provider {
 				Default:     4,
 				Description: "Maximum number of retries",
 			},
-			"api_timeout_max_sec": {
+			"request_timeout_sec": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     120,

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -67,6 +67,12 @@ func Provider() *schema.Provider {
 				Default:     4,
 				Description: "Maximum number of retries",
 			},
+			"api_timeout_max_sec": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     120,
+				Description: "Maximum timeout from upcloud api",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -124,13 +130,12 @@ func Provider() *schema.Provider {
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	
+
 	apiTimeoutMaxSec := time.Duration(d.Get("api_timeout_max_sec").(int)) * time.Second
-	
+
 	config := Config{
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
-		apiTimeoutMaxSec,
 	}
 
 	httpClient := retryablehttp.NewClient()
@@ -153,7 +158,8 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	return service, diags
 }
 
-func newUpCloudServiceConnection(username, password string, httpClient *http.Client) *service.Service {
+func newUpCloudServiceConnection(username, password string, httpClient *http.Client, apiTimeout time.Duration) *service.Service {
+
 	providerClient := client.New(
 		username,
 		password,

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -158,7 +158,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	return service, diags
 }
 
-func newUpCloudServiceConnection(username, password string, httpClient *http.Client, apiTimeout time.Duration) *service.Service {
+func newUpCloudServiceConnection(username, password string, httpClient *http.Client, requestTimeout time.Duration) *service.Service {
 
 	providerClient := client.New(
 		username,

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -164,7 +164,7 @@ func newUpCloudServiceConnection(username, password string, httpClient *http.Cli
 		username,
 		password,
 		client.WithHTTPClient(httpClient),
-		client.WithTimeout(apiTimeout),
+		client.WithTimeout(requestTimeout),
 	)
 
 	providerClient.UserAgent = fmt.Sprintf("terraform-provider-upcloud/%s", config.Version)

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -147,7 +147,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		d.Get("username").(string),
 		d.Get("password").(string),
 		httpClient.HTTPClient,
-		apiTimeoutMaxSec,
+		requestTimeout,
 	)
 
 	_, err := config.checkLogin(service)

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -131,7 +131,7 @@ func Provider() *schema.Provider {
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	apiTimeoutMaxSec := time.Duration(d.Get("api_timeout_max_sec").(int)) * time.Second
+	requestTimeout := time.Duration(d.Get("request_timeout_sec").(int)) * time.Second
 
 	config := Config{
 		Username: d.Get("username").(string),

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -32,8 +32,6 @@ import (
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
-const upcloudAPITimeout time.Duration = time.Second * 120
-
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -159,7 +157,6 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 }
 
 func newUpCloudServiceConnection(username, password string, httpClient *http.Client, requestTimeout time.Duration) *service.Service {
-
 	providerClient := client.New(
 		username,
 		password,

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -71,7 +71,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     120,
-				Description: "Maximum timeout from upcloud api",
+				Description: "The duration (in seconds) that the provider waits for a HTTP request to towards UpCloud API to complete. Defaults to 120 seconds",
 			},
 		},
 

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -32,6 +32,8 @@ import (
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
+const upcloudAPITimeout time.Duration = time.Second * 120
+
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -64,12 +66,6 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Default:     4,
 				Description: "Maximum number of retries",
-			},
-			"api_timeout_max_sec": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     120,
-				Description: "Maximum time wait upcloud api",
 			},
 		},
 
@@ -128,10 +124,13 @@ func Provider() *schema.Provider {
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
-
+	
+	apiTimeoutMaxSec := time.Duration(d.Get("api_timeout_max_sec").(int)) * time.Second
+	
 	config := Config{
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		apiTimeoutMaxSec,
 	}
 
 	httpClient := retryablehttp.NewClient()
@@ -143,6 +142,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		d.Get("username").(string),
 		d.Get("password").(string),
 		httpClient.HTTPClient,
+		apiTimeoutMaxSec,
 	)
 
 	_, err := config.checkLogin(service)
@@ -158,7 +158,7 @@ func newUpCloudServiceConnection(username, password string, httpClient *http.Cli
 		username,
 		password,
 		client.WithHTTPClient(httpClient),
-		client.WithTimeout(api_timeout_max_sec),
+		client.WithTimeout(apiTimeout),
 	)
 
 	providerClient.UserAgent = fmt.Sprintf("terraform-provider-upcloud/%s", config.Version)

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -32,8 +32,6 @@ import (
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
-const upcloudAPITimeout time.Duration = time.Second * 120
-
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -66,6 +64,12 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Default:     4,
 				Description: "Maximum number of retries",
+			},
+			"api_timeout_max_sec": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     120,
+				Description: "Maximum time wait upcloud api",
 			},
 		},
 
@@ -154,7 +158,7 @@ func newUpCloudServiceConnection(username, password string, httpClient *http.Cli
 		username,
 		password,
 		client.WithHTTPClient(httpClient),
-		client.WithTimeout(upcloudAPITimeout),
+		client.WithTimeout(api_timeout_max_sec),
 	)
 
 	providerClient.UserAgent = fmt.Sprintf("terraform-provider-upcloud/%s", config.Version)

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -54,7 +54,9 @@ func init() {
 
 			client := retryablehttp.NewClient()
 
-			service := newUpCloudServiceConnection(username, password, client.HTTPClient)
+			apiTimeoutMaxSec := 120 * time.Second
+
+			service := newUpCloudServiceConnection(username, password, client.HTTPClient, apiTimeoutMaxSec)
 
 			objectStorages, err := service.GetObjectStorages(context.Background())
 			if err != nil {

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -54,7 +54,7 @@ func init() {
 
 			client := retryablehttp.NewClient()
 
-			apiTimeoutMaxSec := 120 * time.Second
+			requestTimeout := 120 * time.Second
 
 			service := newUpCloudServiceConnection(username, password, client.HTTPClient, apiTimeoutMaxSec)
 

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -56,7 +56,7 @@ func init() {
 
 			requestTimeout := 120 * time.Second
 
-			service := newUpCloudServiceConnection(username, password, client.HTTPClient, apiTimeoutMaxSec)
+			service := newUpCloudServiceConnection(username, password, client.HTTPClient, requestTimeout)
 
 			objectStorages, err := service.GetObjectStorages(context.Background())
 			if err != nil {


### PR DESCRIPTION
Hello Team,

I've encountered a recurring issue while deploying infrastructure using Terraform with the UpCloud provider. Specifically, I often receive a timeout error from my Atlantis pipeline, despite the virtual machine (VM) configurations being applied as expected but it's cause the pipeline is detected as failed. This issue seems to be related to the client timeout settings in the UpCloud Terraform provider.

**Error Encountered:**
```bash
Error: Post "https://api.upcloud.com/1.3/server/xxxxxx-xxxxx-4807-b1d4-9e9d944470cf/start": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
with upcloud_server.dbxxxx_managed_by_terraform,
on database.tf line 8, in resource "upcloud_server" "dbxxxx_managed_by_terraform":
8: resource "upcloud_server" "dbxxx_managed_by_terraform" {
```

To address this, I propose enhancing the timeout configuration by allowing users to specify a custom timeout period for API requests. This change could provide greater flexibility in handling longer-running operations, especially in larger or more complex environments.

#### Proposed Changes
1. **Hardcoding the API Timeout:** I've set the API timeout to default duration of 120 seconds. 

2. **Open to Suggestions:** I'm also open to alternative approaches or existing configurable options that I might not be aware of. Any feedback or suggestions from the team would be greatly appreciated.

Looking forward to your feedback and suggestions on this proposed change.
