### PR TITLE
chore: prepare release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [5.1.0] - 2024-03-06
+## [5.1.0] - 2024-03-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [5.1.0] - 2024-03-06
+
 ### Added
 
 - upcloud_managed_database: support for attaching private networks
@@ -531,7 +533,8 @@ Updated upcloud-go-api, added build/CI scripts, and repackaged 0.1.0 as 1.0.0.
 - resource_upcloud_firewall_rule removed and replaced by resource_upcloud_firewall_rules
 - resource_upcloud_zone removed and replaced by zone and zones datasources
 
-[Unreleased]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.0.3...HEAD
+[Unreleased]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.1.0...HEAD
+[5.1.0]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.0.3...v5.1.0
 [5.0.3]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.0.2...v5.0.3
 [5.0.2]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/UpCloudLtd/terraform-provider-upcloud/compare/v5.0.0...v5.0.1


### PR DESCRIPTION
- [x] Update docs: #507 
- [x] Make network UUID required: #509 
- [ ] Include DBaaS sub-resource import fixes: #510 