### PR TITLE
Fix/objsto read error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- managed object storage: fix error when refreshing a state after the resource was deleted outside of Terraform; applies to all upcloud_managed_object_storage* resources
+
 ## [5.2.1] - 2024-03-28
 
 ### Fixed

--- a/internal/service/managedobjectstorage/managed_object_storage.go
+++ b/internal/service/managedobjectstorage/managed_object_storage.go
@@ -205,7 +205,7 @@ func resourceManagedObjectStorageRead(ctx context.Context, d *schema.ResourceDat
 
 	storage, err := svc.GetManagedObjectStorage(ctx, &request.GetManagedObjectStorageRequest{UUID: d.Id()})
 	if err != nil {
-		return diag.FromErr(err)
+		return utils.HandleResourceError(d.Get("name").(string), d, err)
 	}
 
 	return setManagedObjectStorageData(d, storage)

--- a/internal/service/managedobjectstorage/policy.go
+++ b/internal/service/managedobjectstorage/policy.go
@@ -125,7 +125,7 @@ func resourceManagedObjectStoragePolicyRead(ctx context.Context, d *schema.Resou
 		Name:        name,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return utils.HandleResourceError(d.Get("name").(string), d, err)
 	}
 
 	return setManagedObjectStoragePolicyData(d, policy)

--- a/internal/service/managedobjectstorage/user.go
+++ b/internal/service/managedobjectstorage/user.go
@@ -87,7 +87,7 @@ func resourceManagedObjectStorageUserRead(ctx context.Context, d *schema.Resourc
 		Username:    username,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return utils.HandleResourceError(d.Get("username").(string), d, err)
 	}
 
 	return setManagedObjectStorageUserData(d, user)

--- a/internal/service/managedobjectstorage/user_access_key.go
+++ b/internal/service/managedobjectstorage/user_access_key.go
@@ -128,7 +128,7 @@ func resourceManagedObjectStorageUserAccessKeyRead(ctx context.Context, d *schem
 		AccessKeyID: id,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return utils.HandleResourceError(d.Get("access_key_id").(string), d, err)
 	}
 
 	return setManagedObjectStorageUserAccessKeyData(d, accessKey)

--- a/internal/service/managedobjectstorage/user_policy.go
+++ b/internal/service/managedobjectstorage/user_policy.go
@@ -91,7 +91,7 @@ func resourceManagedObjectStorageUserPolicyRead(ctx context.Context, d *schema.R
 		Username:    username,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return utils.HandleResourceError(d.Get("name").(string), d, err)
 	}
 
 	for _, policy := range policies {


### PR DESCRIPTION
This PR fixes the issue for all managed object storage resources, when apply/refresh errors out when you create a resource with TF and then delete it outside TF. The issue was that we didn't remove resource ID from the state on `not found` errors in read functions.