### PR TITLE
test(gateway): add test case that omits all optional fields

### DIFF
--- a/upcloud/gateway/resource_upcloud_gateway_test.go
+++ b/upcloud/gateway/resource_upcloud_gateway_test.go
@@ -164,6 +164,36 @@ func TestAccUpcloudGateway(t *testing.T) {
 	})
 }
 
+func TestAccUpcloudGateway_Minimal(t *testing.T) {
+	testData := utils.ReadTestDataFile(t, "testdata/gateway_minimal.tf")
+	name := "upcloud_gateway.this"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { upcloud.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: upcloud.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testData,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "tf-acc-test-net-gateway-gw"),
+					resource.TestCheckResourceAttr(name, "zone", "pl-waw1"),
+				),
+			},
+			{
+				Config:             testData,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config:            testData,
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccUpcloudGateway_LabelsValidation(t *testing.T) {
 	testDataE := utils.ReadTestDataFile(t, "testdata/gateway_e.tf")
 

--- a/upcloud/gateway/testdata/gateway_minimal.tf
+++ b/upcloud/gateway/testdata/gateway_minimal.tf
@@ -1,0 +1,40 @@
+variable "prefix" {
+  default = "tf-acc-test-net-gateway-"
+  type    = string
+}
+
+variable "zone" {
+  default = "pl-waw1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+
+  lifecycle {
+    ignore_changes = [static_route]
+  }
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  ip_network {
+    address = "172.16.125.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+
+  router = upcloud_router.this.id
+}
+
+resource "upcloud_gateway" "this" {
+  name     = "${var.prefix}gw"
+  zone     = var.zone
+  features = ["nat"]
+
+  router {
+    id = upcloud_router.this.id
+  }
+}


### PR DESCRIPTION
At least one of the data-consistency errors (default value for `configured_status`) requires re-implementation with plugin framework, see also [Hashicorp docs](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/data-consistency-errors#planned-value-for-a-non-computed-attribute).