### PR TITLE
ci: add workflow to automatically run `make generate`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,6 @@ jobs:
           commit-message: "chore(docs): update documentation for #${{ github.event.number }}"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           reviewers: ${{ github.actor }}
-          title: Update documentation
+          title: "chore(docs): update documentation for #${{ github.event.number }}"
           body: "This is an automatically created PR. Changes were created by running `make docs` after merging #${{ github.event.number }} (${{ github.sha }})."
           base: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,52 @@
+name: Generate
+
+on:
+  push:
+    branches:
+      - test-make-generate # for testing
+  workflow_dispatch:
+  schedule:
+    - cron: '30 2 * * *'
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Setup upctl
+        run: |
+          go install github.com/UpCloudLtd/upcloud-cli/v3/...@latest
+      - name: Generate JSON files
+        env:
+          UPCLOUD_USERNAME: ${{ secrets.UPCLOUD_USERNAME }}
+          UPCLOUD_PASSWORD: ${{ secrets.UPCLOUD_PASSWORD }}
+        run: |
+          make generate
+      - name: Store diff in variable
+        id: diff
+        run: |
+          {
+            echo 'DIFF<<EOF'
+            cat $(find internal/ -name "*.diff")
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Create PR for update
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
+        with:
+          add-paths: internal/
+          branch: chore/make-generate
+          commit-message: "chore: update generated code"
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          title: Update generated files
+          body: |
+            This is an automatically created PR. Changes were created by running `make generate`.
+
+            ```diff
+            ${{ steps.diff.outputs.DIFF }}
+            ```

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           add-paths: internal/
           branch: chore/make-generate
-          commit-message: "chore: update generated code"
+          commit-message: "chore: update generated files"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          title: Update generated files
+          title: "chore: update generated files"
           body: |
             This is an automatically created PR. Changes were created by running `make generate`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ terraform/
 
 # Ignore tools installed by make install-tools
 /.ci/bin
+
+# Ignore diff files from make generate
+*.diff

--- a/internal/service/database/properties/generate_types_data.sh
+++ b/internal/service/database/properties/generate_types_data.sh
@@ -7,5 +7,19 @@ if [ -z "$UPCLOUD_USERNAME" ] || [ -z "$UPCLOUD_PASSWORD" ]; then
     exit 1
 fi
 
+cat $target | jq > old_$target
+
 # Fetch DB types data and remove extra fields and whitespace. End-result is a single line JSON file with DB properties objects by database type.
 upctl database types -o json | jq -cM 'map_values({properties})' > $target
+
+cat $target | jq > new_$target
+
+if diff -u old_$target new_$target > $target.diff; then
+    echo "No changes detected."
+else
+    echo "Changes detected. Please review the diff file: $target.diff"
+    echo ""
+    cat $target.diff
+fi
+
+rm -f old_$target new_$target


### PR DESCRIPTION
Also updates the DB properties generate script so that differences are presented in human readable format.