### PR TITLE
fix(storage): sync title length constraint with API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- upcloud_storage: sync title length constraint with API, allows 1-255 characters now
+
 ## [5.8.0] - 2024-07-16
 
 ### Added

--- a/internal/service/storage/storage.go
+++ b/internal/service/storage/storage.go
@@ -54,7 +54,7 @@ func ResourceStorage() *schema.Resource {
 				Description:  "A short, informative description",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"zone": {
 				Description: "The zone in which the storage will be created, e.g. `de-fra1`. You can list available zones with `upctl zone list`.",

--- a/upcloud/resource_upcloud_storage_test.go
+++ b/upcloud/resource_upcloud_storage_test.go
@@ -39,7 +39,7 @@ func TestAccUpcloudStorage_basic(t *testing.T) {
 						encrypt = true
 						size    = 10
 						tier    = "maxiops"
-						title   = "tf-acc-test-storage-basic"
+						title   = "tf-acc-test-storage-basic-with-a-title-consisting-of-64-characters-or-more"
 						zone    = "pl-waw1"
 						filesystem_autoresize = false
 						delete_autoresize_backup = false
@@ -63,7 +63,7 @@ func TestAccUpcloudStorage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"upcloud_storage.this", "tier", "maxiops"),
 					resource.TestCheckResourceAttr(
-						"upcloud_storage.this", "title", "tf-acc-test-storage-basic"),
+						"upcloud_storage.this", "title", "tf-acc-test-storage-basic-with-a-title-consisting-of-64-characters-or-more"),
 					resource.TestCheckResourceAttr(
 						"upcloud_storage.this", "zone", "pl-waw1"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Ref https://developers.upcloud.com/1.3/9-storages/