### PR TITLE
feat(router): add `static_routes` set for listing all routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- upcloud_managed_database_\*: support for labels.
+- upcloud_managed_database_\*: support for labels
+- upcloud_router: add `static_routes` set for listing both user and service defined static routes
+
+### Changed
+
+- upcloud_router: store `attached_networks` values in alphabetical order
+- upcloud_router: do not include service defined routes in the `static_route` set, as those can not be modified or removed by the user
+
+### Fixed
+
+- upcloud_router: remove empty strings from `attached_networks` value
 
 ## [5.8.1] - 2024-07-18
 

--- a/upcloud/testdata/upcloud_router/delete_attached_s1.tf
+++ b/upcloud/testdata/upcloud_router/delete_attached_s1.tf
@@ -1,0 +1,26 @@
+variable "prefix" {
+  default = "tf-acc-test-router-delete-attached-"
+  type    = string
+}
+
+variable "zone" {
+  default = "fi-hel1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  router = upcloud_router.this.id
+
+  ip_network {
+    address = "10.0.3.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+}

--- a/upcloud/testdata/upcloud_router/delete_attached_s2.tf
+++ b/upcloud/testdata/upcloud_router/delete_attached_s2.tf
@@ -1,0 +1,22 @@
+variable "prefix" {
+  default = "tf-acc-test-router-delete-attached-"
+  type    = string
+}
+
+variable "zone" {
+  default = "fi-hel1"
+  type    = string
+}
+
+# Delete the router
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  ip_network {
+    address = "10.0.3.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+}

--- a/upcloud/testdata/upcloud_router/detach_s1.tf
+++ b/upcloud/testdata/upcloud_router/detach_s1.tf
@@ -1,0 +1,26 @@
+variable "prefix" {
+  default = "tf-acc-test-router-detach-"
+  type    = string
+}
+
+variable "zone" {
+  default = "fi-hel1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  router = upcloud_router.this.id
+
+  ip_network {
+    address = "10.0.2.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+}

--- a/upcloud/testdata/upcloud_router/detach_s2.tf
+++ b/upcloud/testdata/upcloud_router/detach_s2.tf
@@ -1,0 +1,26 @@
+variable "prefix" {
+  default = "tf-acc-test-router-detach-"
+  type    = string
+}
+
+variable "zone" {
+  default = "fi-hel1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  # router = upcloud_router.this.id 
+
+  ip_network {
+    address = "10.0.2.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+}

--- a/upcloud/testdata/upcloud_router/static_routes_s1.tf
+++ b/upcloud/testdata/upcloud_router/static_routes_s1.tf
@@ -1,0 +1,37 @@
+variable "prefix" {
+  default = "tf-acc-test-router-static-routes-"
+  type    = string
+}
+
+variable "zone" {
+  default = "pl-waw1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  ip_network {
+    address = "192.168.120.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+
+  router = upcloud_router.this.id
+}
+
+# The gateway is used to create service route to the routers static routes.
+resource "upcloud_gateway" "this" {
+  name     = "${var.prefix}gw"
+  zone     = var.zone
+  features = ["nat"]
+
+  router {
+    id = upcloud_router.this.id
+  }
+}

--- a/upcloud/testdata/upcloud_router/static_routes_s2.tf
+++ b/upcloud/testdata/upcloud_router/static_routes_s2.tf
@@ -1,0 +1,43 @@
+variable "prefix" {
+  default = "tf-acc-test-router-static-routes-"
+  type    = string
+}
+
+variable "zone" {
+  default = "pl-waw1"
+  type    = string
+}
+
+resource "upcloud_router" "this" {
+  name = "${var.prefix}router"
+
+  static_route {
+    name    = "test"
+    route   = "192.168.240.0/24"
+    nexthop = "192.168.240.10"
+  }
+}
+
+resource "upcloud_network" "this" {
+  name = "${var.prefix}net"
+  zone = var.zone
+
+  ip_network {
+    address = "192.168.120.0/24"
+    dhcp    = true
+    family  = "IPv4"
+  }
+
+  router = upcloud_router.this.id
+}
+
+# The gateway is used to create service route to the routers static routes.
+resource "upcloud_gateway" "this" {
+  name     = "${var.prefix}gw"
+  zone     = var.zone
+  features = ["nat"]
+
+  router {
+    id = upcloud_router.this.id
+  }
+}


### PR DESCRIPTION
Also fixes `attached_networks` order, removes unwanted empty string from `attached_networks`, and removes service
routes from `static_route` set.