### PR TITLE
fix(objsto): ignore whitespace and extra escapes in policy document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - upcloud_storage: add support for labels
 
+### Changed
+
+- upcloud_managed_object_storage_policy: store configured value instead of the value returned by the API in the Terraform state. The provider will raise an error if these documents do not match
+
 ### Fixed
 
 - upcloud_storage: use `source_hash` to automatically verify the integrity of the imported data. Previously, the value was stored to state, but no validations were done
+- upcloud_managed_object_storage_policy: ignore whitespace and unnecessary escapes when determining if policy document has changed
 
 ## [5.9.1] - 2024-08-05
 

--- a/internal/service/loadbalancer/frontend.go
+++ b/internal/service/loadbalancer/frontend.go
@@ -316,7 +316,6 @@ func (r *frontendResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	if data.ID.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
-
 		return
 	}
 

--- a/internal/service/managedobjectstorage/policies_data_source.go
+++ b/internal/service/managedobjectstorage/policies_data_source.go
@@ -10,6 +10,65 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func schemaPolicy() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"arn": {
+			Description: "Policy ARN.",
+			Computed:    true,
+			Type:        schema.TypeString,
+		},
+		"attachment_count": {
+			Description: "Attachment count.",
+			Computed:    true,
+			Type:        schema.TypeInt,
+		},
+		"created_at": {
+			Description: "Creation time.",
+			Computed:    true,
+			Type:        schema.TypeString,
+		},
+		"default_version_id": {
+			Description: "Default version id.",
+			Computed:    true,
+			Type:        schema.TypeString,
+		},
+		"description": {
+			Description: "Description of the policy.",
+			Optional:    true,
+			ForceNew:    true,
+			Type:        schema.TypeString,
+		},
+		"document": {
+			Description: "Policy document, URL-encoded compliant with RFC 3986.",
+			Required:    true,
+			ForceNew:    true,
+			Type:        schema.TypeString,
+		},
+		"name": {
+			Description: "Policy name.",
+			Required:    true,
+			ForceNew:    true,
+			Type:        schema.TypeString,
+		},
+		"service_uuid": {
+			Description: "Managed Object Storage service UUID.",
+			Required:    true,
+			ForceNew:    true,
+			Type:        schema.TypeString,
+		},
+		"system": {
+			Description: "Defines whether the policy was set up by the system.",
+			Computed:    true,
+			Type:        schema.TypeBool,
+		},
+		"updated_at": {
+			Description: "Update time.",
+			Computed:    true,
+			Type:        schema.TypeString,
+		},
+	}
+}
+
 func DataSourceManagedObjectStoragePolicies() *schema.Resource {
 	return &schema.Resource{
 		Description: "Policies available for a Managed Object Storage resource. See `managed_object_storage_user_policy` for attaching to a user.",

--- a/internal/service/managedobjectstorage/policy.go
+++ b/internal/service/managedobjectstorage/policy.go
@@ -2,183 +2,345 @@ package managedobjectstorage
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
-
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func ResourceManagedObjectStoragePolicy() *schema.Resource {
-	return &schema.Resource{
-		Description:   "This resource represents an UpCloud Managed Object Storage policy.",
-		CreateContext: resourceManagedObjectStoragePolicyCreate,
-		ReadContext:   resourceManagedObjectStoragePolicyRead,
-		DeleteContext: resourceManagedObjectStoragePolicyDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+var (
+	_ resource.Resource                = &managedObjectStoragePolicyResource{}
+	_ resource.ResourceWithConfigure   = &managedObjectStoragePolicyResource{}
+	_ resource.ResourceWithImportState = &managedObjectStoragePolicyResource{}
+)
+
+func NewManagedObjectStoragePolicyResource() resource.Resource {
+	return &managedObjectStoragePolicyResource{}
+}
+
+type managedObjectStoragePolicyResource struct {
+	client *service.Service
+}
+
+func (r *managedObjectStoragePolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_managed_object_storage_policy"
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *managedObjectStoragePolicyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.client, resp.Diagnostics = utils.GetClientFromProviderData(req.ProviderData)
+}
+
+type policyModel struct {
+	ARN              types.String `tfsdk:"arn"`
+	AttachmentCount  types.Int64  `tfsdk:"attachment_count"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	DefaultVersionID types.String `tfsdk:"default_version_id"`
+	Description      types.String `tfsdk:"description"`
+	Document         types.String `tfsdk:"document"`
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	ServiceUUID      types.String `tfsdk:"service_uuid"`
+	System           types.Bool   `tfsdk:"system"`
+	UpdatedAt        types.String `tfsdk:"updated_at"`
+}
+
+func policySchema(_ int64) schema.Schema {
+	return schema.Schema{
+		// Version:     version,
+		Description: "This resource represents an UpCloud Managed Object Storage policy.",
+		Attributes: map[string]schema.Attribute{
+			"arn": schema.StringAttribute{
+				Description: "Policy ARN.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"attachment_count": schema.Int64Attribute{
+				Description: "Attachment count.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Creation time.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"default_version_id": schema.StringAttribute{
+				Description: "Default version id.",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Description of the policy.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"document": schema.StringAttribute{
+				Description: "Policy document, URL-encoded compliant with RFC 3986. The document is stored in state without extra whitespace or escapes.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIf(
+						policyDocumentRequiresReplace,
+						policyDocumentRequiresReplaceDescription,
+						policyDocumentRequiresReplaceDescription,
+					),
+				},
+			},
+			"id": schema.StringAttribute{
+				Description: "ID of the policy. ID is in {object storage UUID}/{policy name} format.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Policy name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"service_uuid": schema.StringAttribute{
+				Description: "Managed Object Storage service UUID.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.BoolAttribute{
+				Description: "Defines whether the policy was set up by the system.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Update time.",
+				Computed:    true,
+			},
 		},
-		Schema: schemaPolicy(),
 	}
 }
 
-func schemaPolicy() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"arn": {
-			Description: "Policy ARN.",
-			Computed:    true,
-			Type:        schema.TypeString,
-		},
-		"attachment_count": {
-			Description: "Attachment count.",
-			Computed:    true,
-			Type:        schema.TypeInt,
-		},
-		"created_at": {
-			Description: "Creation time.",
-			Computed:    true,
-			Type:        schema.TypeString,
-		},
-		"default_version_id": {
-			Description: "Default version id.",
-			Computed:    true,
-			Type:        schema.TypeString,
-		},
-		"description": {
-			Description: "Description of the policy.",
-			Optional:    true,
-			ForceNew:    true,
-			Type:        schema.TypeString,
-		},
-		"document": {
-			Description: "Policy document, URL-encoded compliant with RFC 3986.",
-			Required:    true,
-			ForceNew:    true,
-			Type:        schema.TypeString,
-		},
-		"name": {
-			Description: "Policy name.",
-			Required:    true,
-			ForceNew:    true,
-			Type:        schema.TypeString,
-		},
-		"service_uuid": {
-			Description: "Managed Object Storage service UUID.",
-			Required:    true,
-			ForceNew:    true,
-			Type:        schema.TypeString,
-		},
-		"system": {
-			Description: "Defines whether the policy was set up by the system.",
-			Computed:    true,
-			Type:        schema.TypeBool,
-		},
-		"updated_at": {
-			Description: "Update time.",
-			Computed:    true,
-			Type:        schema.TypeString,
-		},
-	}
+func (r *managedObjectStoragePolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = policySchema(1)
 }
 
-func resourceManagedObjectStoragePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
-	svc := meta.(*service.Service)
+func setPolicyValues(_ context.Context, data *policyModel, policy *upcloud.ManagedObjectStoragePolicy) diag.Diagnostics {
+	var respDiagnostics diag.Diagnostics
 
-	req := &request.CreateManagedObjectStoragePolicyRequest{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Document:    d.Get("document").(string),
-		ServiceUUID: d.Get("service_uuid").(string),
+	data.ARN = types.StringValue(policy.ARN)
+	data.AttachmentCount = types.Int64Value(int64(policy.AttachmentCount))
+	data.CreatedAt = types.StringValue(policy.CreatedAt.String())
+	data.DefaultVersionID = types.StringValue(policy.DefaultVersionID)
+	data.Description = types.StringValue(policy.Description)
+	data.Name = types.StringValue(policy.Name)
+	data.System = types.BoolValue(policy.System)
+	data.UpdatedAt = types.StringValue(policy.UpdatedAt.String())
+
+	apiDocument, diags := normalizePolicyDocument(policy.Document)
+	respDiagnostics.Append(diags...)
+	// Document is required, so it should only be empty during import.
+	if data.Document.IsNull() {
+		data.Document = types.StringValue(apiDocument)
 	}
 
-	policy, err := svc.CreateManagedObjectStoragePolicy(ctx, req)
+	configDocument, diags := normalizePolicyDocument(data.Document.ValueString())
+	respDiagnostics.Append(diags...)
+
+	if configDocument != apiDocument {
+		respDiagnostics.AddError(
+			"Configured policy document does not match the policy document in the API response",
+			fmt.Sprintf("Configured:   %s\nAPI response: %s", configDocument, apiDocument),
+		)
+	}
+
+	return respDiagnostics
+}
+
+func (r *managedObjectStoragePolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data policyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = types.StringValue(utils.MarshalID(data.ServiceUUID.ValueString(), data.Name.ValueString()))
+
+	apiReq := &request.CreateManagedObjectStoragePolicyRequest{
+		Name:        data.Name.ValueString(),
+		Description: data.Description.ValueString(),
+		Document:    data.Document.ValueString(),
+		ServiceUUID: data.ServiceUUID.ValueString(),
+	}
+
+	policy, err := r.client.CreateManagedObjectStoragePolicy(ctx, apiReq)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Unable to create managed object storage policy",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
 	}
 
-	d.SetId(utils.MarshalID(req.ServiceUUID, req.Name))
-
-	return setManagedObjectStoragePolicyData(d, policy)
+	resp.Diagnostics.Append(setPolicyValues(ctx, &data, policy)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceManagedObjectStoragePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	svc := meta.(*service.Service)
+func (r *managedObjectStoragePolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data policyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	var serviceUUID, name string
-	if err := utils.UnmarshalID(d.Id(), &serviceUUID, &name); err != nil {
-		return diag.FromErr(err)
+	err := utils.UnmarshalID(data.ID.ValueString(), &serviceUUID, &name)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to unmarshal managed object storage policy ID",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
 	}
+	data.ServiceUUID = types.StringValue(serviceUUID)
 
-	// If service UUID is not set already set it based on the Id. This is the case for example when importing existing policy.
-	if _, ok := d.GetOk("service_uuid"); !ok {
-		err := d.Set("service_uuid", serviceUUID)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	policy, err := svc.GetManagedObjectStoragePolicy(ctx, &request.GetManagedObjectStoragePolicyRequest{
-		ServiceUUID: serviceUUID,
+	policy, err := r.client.GetManagedObjectStoragePolicy(ctx, &request.GetManagedObjectStoragePolicyRequest{
 		Name:        name,
+		ServiceUUID: serviceUUID,
 	})
 	if err != nil {
-		return utils.HandleResourceError(d.Get("name").(string), d, err)
+		if utils.IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Unable to read managed object storage policy details",
+				utils.ErrorDiagnosticDetail(err),
+			)
+		}
+		return
 	}
 
-	return setManagedObjectStoragePolicyData(d, policy)
+	resp.Diagnostics.Append(setPolicyValues(ctx, &data, policy)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceManagedObjectStoragePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	svc := meta.(*service.Service)
+func (r *managedObjectStoragePolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data policyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policy, err := r.client.GetManagedObjectStoragePolicy(ctx, &request.GetManagedObjectStoragePolicyRequest{
+		Name:        data.Name.ValueString(),
+		ServiceUUID: data.ServiceUUID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read managed object storage policy details",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(setPolicyValues(ctx, &data, policy)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *managedObjectStoragePolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data policyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	var serviceUUID, name string
-	if err := utils.UnmarshalID(d.Id(), &serviceUUID, &name); err != nil {
-		return diag.FromErr(err)
+	if err := utils.UnmarshalID(data.ID.ValueString(), &serviceUUID, &name); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to unmarshal managed object storage policy ID",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
 	}
 
-	req := &request.DeleteManagedObjectStoragePolicyRequest{
+	if err := r.client.DeleteManagedObjectStoragePolicy(ctx, &request.DeleteManagedObjectStoragePolicyRequest{
 		ServiceUUID: serviceUUID,
 		Name:        name,
+	}); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete managed object storage policy",
+			utils.ErrorDiagnosticDetail(err),
+		)
 	}
-
-	if err := svc.DeleteManagedObjectStoragePolicy(ctx, req); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
 }
 
-func setManagedObjectStoragePolicyData(d *schema.ResourceData, policy *upcloud.ManagedObjectStoragePolicy) (diags diag.Diagnostics) {
-	if err := d.Set("arn", policy.ARN); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("attachment_count", policy.AttachmentCount); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("created_at", policy.CreatedAt.String()); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("default_version_id", policy.DefaultVersionID); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("description", policy.Description); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("document", policy.Document); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("name", policy.Name); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("system", policy.System); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("updated_at", policy.UpdatedAt.String()); err != nil {
-		return diag.FromErr(err)
+func (r *managedObjectStoragePolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+var _ stringplanmodifier.RequiresReplaceIfFunc = policyDocumentRequiresReplace
+
+const policyDocumentRequiresReplaceDescription = "Policy document requires replace if the document in state does not match planned document after removing whitespace and unnecessary escapes."
+
+func policyDocumentRequiresReplace(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+	var plan, state policyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	planDocument, diags := normalizePolicyDocument(plan.Document.ValueString())
+	resp.Diagnostics.Append(diags...)
+	stateDocument, diags := normalizePolicyDocument(state.Document.ValueString())
+	resp.Diagnostics.Append(diags...)
+
+	resp.RequiresReplace = planDocument != stateDocument
+}
+
+func normalizePolicyDocument(document string) (string, diag.Diagnostics) {
+	errToDiags := func(err error) (diags diag.Diagnostics) {
+		diags.AddError(
+			"Unable to normalize object storage policy document",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
 	}
 
-	return diags
+	unescaped, err := url.QueryUnescape(document)
+	if err != nil {
+		return "", errToDiags(err)
+	}
+
+	var unmarshaled interface{}
+	err = json.Unmarshal([]byte(unescaped), &unmarshaled)
+	if err != nil {
+		return "", errToDiags(err)
+	}
+
+	marshaled, err := json.Marshal(unmarshaled)
+	if err != nil {
+		return "", errToDiags(err)
+	}
+
+	return url.QueryEscape(string(marshaled)), nil
 }

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -145,6 +145,7 @@ func (p *upcloudProvider) Resources(_ context.Context) []func() resource.Resourc
 		kubernetes.NewKubernetesClusterResource,
 		loadbalancer.NewFrontendResource,
 		loadbalancer.NewManualCertificateBundleResource,
+		managedobjectstorage.NewManagedObjectStoragePolicyResource,
 		network.NewNetworkResource,
 		networkpeering.NewNetworkPeeringResource,
 		router.NewRouterResource,

--- a/upcloud/resource_upcloud_managed_object_storage_user_test.go
+++ b/upcloud/resource_upcloud_managed_object_storage_user_test.go
@@ -24,14 +24,19 @@ func TestAccUpcloudManagedObjectStorageUser(t *testing.T) {
 			{
 				Config: testDataS1,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(storage, "name", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(policy, "name", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(user, "username", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(userAccessKey, "username", "tf-acc-test-objstov2-user"),
+					resource.TestCheckResourceAttr(storage, "name", "tf-acc-test-objstov2-iam-objsto"),
+					resource.TestCheckResourceAttr(policy, "name", "get-user-policy"),
+					resource.TestCheckResourceAttr(user, "username", "tf-acc-test-objstov2-iam-user"),
+					resource.TestCheckResourceAttr(userAccessKey, "username", "tf-acc-test-objstov2-iam-user"),
 					resource.TestCheckResourceAttr(userAccessKey, "status", "Active"),
-					resource.TestCheckResourceAttr(userPolicy, "username", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(userPolicy, "name", "tf-acc-test-objstov2-user"),
+					resource.TestCheckResourceAttr(userPolicy, "username", "tf-acc-test-objstov2-iam-user"),
+					resource.TestCheckResourceAttr(userPolicy, "name", "get-user-policy"),
 				),
+			},
+			{
+				// Validate that there are no changes planned (to e.g. policy document because of server side formatting changes)
+				Config:   testDataS1,
+				PlanOnly: true,
 			},
 			{
 				Config:            testDataS1,
@@ -61,10 +66,10 @@ func TestAccUpcloudManagedObjectStorageUser(t *testing.T) {
 			{
 				Config: testDataS2,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(storage, "name", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(policy, "name", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(user, "username", "tf-acc-test-objstov2-user"),
-					resource.TestCheckResourceAttr(userAccessKey, "username", "tf-acc-test-objstov2-user"),
+					resource.TestCheckResourceAttr(storage, "name", "tf-acc-test-objstov2-iam-objsto"),
+					resource.TestCheckResourceAttr(policy, "name", "get-user-policy"),
+					resource.TestCheckResourceAttr(user, "username", "tf-acc-test-objstov2-iam-user"),
+					resource.TestCheckResourceAttr(userAccessKey, "username", "tf-acc-test-objstov2-iam-user"),
 					resource.TestCheckResourceAttr(userAccessKey, "status", "Inactive"),
 				),
 			},

--- a/upcloud/sdkv2_provider.go
+++ b/upcloud/sdkv2_provider.go
@@ -85,7 +85,6 @@ func Provider() *schema.Provider {
 			"upcloud_managed_database_user":                   database.ResourceUser(),
 			"upcloud_managed_database_logical_database":       database.ResourceLogicalDatabase(),
 			"upcloud_managed_object_storage":                  managedobjectstorage.ResourceManagedObjectStorage(),
-			"upcloud_managed_object_storage_policy":           managedobjectstorage.ResourceManagedObjectStoragePolicy(),
 			"upcloud_managed_object_storage_user":             managedobjectstorage.ResourceManagedObjectStorageUser(),
 			"upcloud_managed_object_storage_user_access_key":  managedobjectstorage.ResourceManagedObjectStorageUserAccessKey(),
 			"upcloud_managed_object_storage_user_policy":      managedobjectstorage.ResourceManagedObjectStorageUserPolicy(),


### PR DESCRIPTION
Also migrates `upcloud_managed_object_storage_policy` to Terraform plugin framework.