### PR TITLE
ci(release): bump go to 1.22 in Dockerfile

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 FROM golang:$GO_VERSION
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y unzip


### PR DESCRIPTION
To match the version defined in `go.mod`, set `GO_VERSION` in `Dockerfile` to 1.22.