### PR TITLE
refactor(server): migrate server resource to plugin framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- upcloud_server: make template storage tier configurable.
+
+### Fixed
+
+- upcloud_server: mark network interface IP address values as unknown during planning. This ensures that IP addresses have known values after apply.
+
 ## [5.16.0] - 2024-12-03
 
 ### Added
+
 - upcloud_managed_database_\*: add `termination_protection` field.
 
 ## [5.15.0] - 2024-11-14

--- a/internal/service/server/create_request.go
+++ b/internal/service/server/create_request.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func buildLoginOpts(ctx context.Context, data loginModel) (*request.LoginUser, string, diag.Diagnostics) {
+	r := &request.LoginUser{}
+
+	r.Username = data.User.ValueString()
+
+	if !data.CreatePassword.IsNull() {
+		if data.CreatePassword.ValueBool() {
+			r.CreatePassword = "yes"
+		} else {
+			r.CreatePassword = "no"
+		}
+	}
+
+	var keys []string
+	diags := data.Keys.ElementsAs(ctx, &keys, false)
+	for _, key := range keys {
+		r.SSHKeys = append(r.SSHKeys, key)
+	}
+
+	return r, data.PasswordDelivery.ValueString(), diags
+}
+
+func buildSimpleBackupOpts(data *simpleBackupModel) string {
+	if data == nil {
+		return "no"
+	}
+
+	time := data.Time.ValueString()
+	plan := data.Plan.ValueString()
+
+	if time != "" && plan != "" {
+		return fmt.Sprintf("%s,%s", time, plan)
+	}
+
+	return "no"
+}
+
+func buildStorageDeviceAddress(address, position string) string {
+	if position != "" {
+		return fmt.Sprintf("%s:%s", address, position)
+	}
+
+	return address
+}
+
+func buildNetworkOpts(ctx context.Context, data serverModel) (req []request.CreateServerInterface, diags diag.Diagnostics) {
+	var ifaces []networkInterfaceModel
+	diags.Append(data.NetworkInterfaces.ElementsAs(context.Background(), &ifaces, false)...)
+
+	for _, iface := range ifaces {
+		r := request.CreateServerInterface{
+			Bootable: upcloud.FromBool(iface.Bootable.ValueBool()),
+			Index:    int(iface.Index.ValueInt64()),
+			IPAddresses: []request.CreateServerIPAddress{
+				{
+					Family:  iface.IPAddressFamily.ValueString(),
+					Address: iface.IPAddress.ValueString(),
+				},
+			},
+			Network:           iface.Network.ValueString(),
+			SourceIPFiltering: upcloud.FromBool(iface.SourceIPFiltering.ValueBool()),
+			Type:              iface.Type.ValueString(),
+		}
+
+		if !iface.AdditionalIPAddresses.IsNull() {
+			if r.Type != upcloud.NetworkTypePrivate {
+				diags.AddError("Invalid configuration", "additional_ip_address can only be set for private network interfaces")
+				return
+			}
+
+			var additionalIPAddresses []additionalIPAddressModel
+			diags.Append(iface.AdditionalIPAddresses.ElementsAs(ctx, &additionalIPAddresses, false)...)
+
+			for _, ipAddress := range additionalIPAddresses {
+				r.IPAddresses = append(r.IPAddresses, request.CreateServerIPAddress{
+					Family:  ipAddress.IPAddressFamily.ValueString(),
+					Address: ipAddress.IPAddress.ValueString(),
+				})
+			}
+		}
+
+		req = append(req, r)
+	}
+
+	return
+}

--- a/internal/service/server/interfaces.go
+++ b/internal/service/server/interfaces.go
@@ -50,10 +50,6 @@ type ifaceChange struct {
 	state     *networkInterfaceModel
 }
 
-func intPtr(i int) *int {
-	return &i
-}
-
 func matchInterfaces(api []upcloud.ServerInterface, state, plan []networkInterfaceModel) map[int]ifaceChange {
 	m := make(map[int]ifaceChange)
 
@@ -68,7 +64,7 @@ func matchInterfaces(api []upcloud.ServerInterface, state, plan []networkInterfa
 		for j, planIface := range plan {
 			if planIface.Index.ValueInt64() == int64(apiIface.Index) {
 				change.plan = &planIface
-				change.planIndex = intPtr(j)
+				change.planIndex = upcloud.IntPtr(j)
 				matchedPlanIfaces[j] = true
 				break
 			}
@@ -95,7 +91,7 @@ func matchInterfaces(api []upcloud.ServerInterface, state, plan []networkInterfa
 					}
 					if canModifyInterface(&stateIface, &planIface, &apiIface) {
 						change.plan = &planIface
-						change.planIndex = intPtr(k)
+						change.planIndex = upcloud.IntPtr(k)
 						matchedPlanIfaces[k] = true
 						break
 					}

--- a/internal/service/server/interfaces.go
+++ b/internal/service/server/interfaces.go
@@ -22,6 +22,15 @@ func findInterface(ifaces []upcloud.ServerInterface, index int) *upcloud.ServerI
 	return nil
 }
 
+func findIPAddress(iface upcloud.ServerInterface, address string) *upcloud.IPAddress {
+	for _, ip := range iface.IPAddresses {
+		if ip.Address == address {
+			return &ip
+		}
+	}
+	return nil
+}
+
 func ipAndTypeMatches(api upcloud.ServerInterface, data networkInterfaceModel) bool {
 	if api.Type != data.Type.ValueString() {
 		return false

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -8,18 +8,31 @@ import (
 	"strings"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/storage"
-	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
-	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/validator"
 
+	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
+	validatorutil "github.com/UpCloudLtd/terraform-provider-upcloud/internal/validator"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
@@ -32,1119 +45,934 @@ const (
     ` + storage.BackupRuleSimpleBackupWarning
 )
 
-func ResourceServer() *schema.Resource {
-	s := resourceServerV0()
-	s.SchemaVersion = 1
-	s.StateUpgraders = []schema.StateUpgrader{
-		{
-			Type:    resourceServerV0().CoreConfigSchema().ImpliedType(),
-			Upgrade: resourceServerStateUpgradeV0,
-			Version: 0,
-		},
-	}
+var (
+	_ resource.Resource                 = &serverResource{}
+	_ resource.ResourceWithConfigure    = &serverResource{}
+	_ resource.ResourceWithImportState  = &serverResource{}
+	_ resource.ResourceWithModifyPlan   = &serverResource{}
+	_ resource.ResourceWithUpgradeState = &serverResource{}
+)
 
-	return s
+func NewServerResource() resource.Resource {
+	return &serverResource{}
 }
 
-func resourceServerV0() *schema.Resource {
-	return &schema.Resource{
-		Description:   "The UpCloud server resource allows the creation, update and deletion of a [cloud server](https://upcloud.com/products/cloud-servers).",
-		CreateContext: resourceServerCreate,
-		ReadContext:   resourceServerRead,
-		UpdateContext: resourceServerUpdate,
-		DeleteContext: resourceServerDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"hostname": {
-				Description: "A valid domain name",
-				Type:        schema.TypeString,
-				Required:    true,
-				ValidateDiagFunc: validation.AllDiag(
-					validation.ToDiagFunc(
-						validation.StringLenBetween(1, 128),
-					),
-					validator.ValidateDomainNameDiag,
-				),
+type serverResource struct {
+	client *service.Service
+}
+
+func (r *serverResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_server"
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *serverResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.client, resp.Diagnostics = utils.GetClientFromProviderData(req.ProviderData)
+}
+
+type serverModel struct {
+	ID                types.String `tfsdk:"id"`
+	Hostname          types.String `tfsdk:"hostname"`
+	Title             types.String `tfsdk:"title"`
+	Zone              types.String `tfsdk:"zone"`
+	ServerGroup       types.String `tfsdk:"server_group"`
+	Firewall          types.Bool   `tfsdk:"firewall"`
+	Metadata          types.Bool   `tfsdk:"metadata"`
+	CPU               types.Int64  `tfsdk:"cpu"`
+	Mem               types.Int64  `tfsdk:"mem"`
+	Timezone          types.String `tfsdk:"timezone"`
+	VideoModel        types.String `tfsdk:"video_model"`
+	NICModel          types.String `tfsdk:"nic_model"`
+	Tags              types.Set    `tfsdk:"tags"`
+	Host              types.Int64  `tfsdk:"host"`
+	NetworkInterfaces types.List   `tfsdk:"network_interface"`
+	Labels            types.Map    `tfsdk:"labels"`
+	UserData          types.String `tfsdk:"user_data"`
+	Plan              types.String `tfsdk:"plan"`
+	StorageDevices    types.Set    `tfsdk:"storage_devices"`
+	Template          types.List   `tfsdk:"template"`
+	Login             types.Set    `tfsdk:"login"`
+	SimpleBackup      types.Set    `tfsdk:"simple_backup"`
+	BootOrder         types.String `tfsdk:"boot_order"`
+}
+
+type networkInterfaceModel struct {
+	Index                 types.Int64  `tfsdk:"index"`
+	IPAddressFamily       types.String `tfsdk:"ip_address_family"`
+	IPAddress             types.String `tfsdk:"ip_address"`
+	IPAddressFloating     types.Bool   `tfsdk:"ip_address_floating"`
+	AdditionalIPAddresses types.Set    `tfsdk:"additional_ip_address"`
+	MACAddress            types.String `tfsdk:"mac_address"`
+	Type                  types.String `tfsdk:"type"`
+	Network               types.String `tfsdk:"network"`
+	SourceIPFiltering     types.Bool   `tfsdk:"source_ip_filtering"`
+	Bootable              types.Bool   `tfsdk:"bootable"`
+}
+
+type additionalIPAddressModel struct {
+	IPAddressFamily   types.String `tfsdk:"ip_address_family"`
+	IPAddress         types.String `tfsdk:"ip_address"`
+	IPAddressFloating types.Bool   `tfsdk:"ip_address_floating"`
+}
+
+func (m additionalIPAddressModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"ip_address_family":   types.StringType,
+		"ip_address":          types.StringType,
+		"ip_address_floating": types.BoolType,
+	}
+}
+
+type storageDeviceModel struct {
+	Address         types.String `tfsdk:"address"`
+	AddressPosition types.String `tfsdk:"address_position"`
+	Storage         types.String `tfsdk:"storage"`
+	Type            types.String `tfsdk:"type"`
+}
+
+type templateModel struct {
+	ID                     types.String `tfsdk:"id"`
+	Address                types.String `tfsdk:"address"`
+	AddressPosition        types.String `tfsdk:"address_position"`
+	Encrypt                types.Bool   `tfsdk:"encrypt"`
+	Size                   types.Int64  `tfsdk:"size"`
+	Tier                   types.String `tfsdk:"tier"`
+	Title                  types.String `tfsdk:"title"`
+	Storage                types.String `tfsdk:"storage"`
+	BackupRule             types.List   `tfsdk:"backup_rule"`
+	FilesystemAutoresize   types.Bool   `tfsdk:"filesystem_autoresize"`
+	DeleteAutoresizeBackup types.Bool   `tfsdk:"delete_autoresize_backup"`
+}
+
+type loginModel struct {
+	User             types.String `tfsdk:"user"`
+	Keys             types.List   `tfsdk:"keys"`
+	CreatePassword   types.Bool   `tfsdk:"create_password"`
+	PasswordDelivery types.String `tfsdk:"password_delivery"`
+}
+
+type simpleBackupModel struct {
+	Plan types.String `tfsdk:"plan"`
+	Time types.String `tfsdk:"time"`
+}
+
+func (r *serverResource) getSchema(version int64) schema.Schema {
+	return schema.Schema{
+		Version:             version,
+		MarkdownDescription: "The UpCloud server resource allows the creation, update and deletion of a [cloud server](https://upcloud.com/products/cloud-servers).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the server.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"title": {
-				Description:  "A short, informational description",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, serverTitleLength),
+			"hostname": schema.StringAttribute{
+				MarkdownDescription: "The hostname of the server.",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 128),
+					validatorutil.IsDomainName(),
+				},
 			},
-			"zone": {
+			"title": schema.StringAttribute{
+				MarkdownDescription: "A short, informational description of the server.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, serverTitleLength),
+				},
+			},
+			"zone": schema.StringAttribute{
 				Description: "The zone in which the server will be hosted, e.g. `de-fra1`. You can list available zones with `upctl zone list`.",
-				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"server_group": {
-				Type:        schema.TypeString,
+			"server_group": schema.StringAttribute{
 				Description: "The UUID of a server group to attach this server to. Note that the server can also be attached to a server group via the `members` property of `upcloud_server_group`. Only one of the these should be defined at a time. This value is only updated if it has been set to non-zero value.",
-				Default:     "",
 				Optional:    true,
 			},
-			"firewall": {
+			"firewall": schema.BoolAttribute{
 				Description: "Are firewall rules active for the server",
-				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"metadata": schema.BoolAttribute{
+				Description: "Is metadata service active for the server",
 				Optional:    true,
 			},
-			"metadata": {
-				Description: "Is the metadata service active for the server",
-				Type:        schema.TypeBool,
-				Optional:    true,
-			},
-			"cpu": {
-				Description:   "The number of CPU for the server",
-				Type:          schema.TypeInt,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"plan"},
-			},
-			"mem": {
-				Description:   "The size of memory for the server (in megabytes)",
-				Type:          schema.TypeInt,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"plan"},
-			},
-			"timezone": {
-				Description: "A timezone identifier, e.g. `Europe/Helsinki`",
-				Type:        schema.TypeString,
+			"cpu": schema.Int64Attribute{
+				Description: "The number of CPU cores for the server",
 				Optional:    true,
 				Computed:    true,
 			},
-			"video_model": {
+			"mem": schema.Int64Attribute{
+				Description: "The amount of memory for the server (in megabytes)",
+				Optional:    true,
+				Computed:    true,
+			},
+			"timezone": schema.StringAttribute{
+				Description: "The timezone of the server. The timezone must be a valid timezone string, e.g. `Europe/Helsinki`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"video_model": schema.StringAttribute{
 				Description: "The model of the server's video interface",
-				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
-					switch v.(string) {
-					case upcloud.VideoModelCirrus, upcloud.VideoModelVGA:
-						return nil
-					default:
-						return diag.Diagnostics{diag.Diagnostic{
-							Severity: diag.Error,
-							Summary:  "'video_model' has incorrect value",
-							Detail: fmt.Sprintf(
-								"'video_model' must be one of %s or %s",
-								upcloud.VideoModelCirrus,
-								upcloud.VideoModelVGA),
-						}}
-					}
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						upcloud.VideoModelCirrus,
+						upcloud.VideoModelVGA,
+					),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"nic_model": {
+			"nic_model": schema.StringAttribute{
 				Description: "The model of the server's network interfaces",
-				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
-					switch v.(string) {
-					case upcloud.NICModelE1000, upcloud.NICModelVirtio, upcloud.NICModelRTL8139:
-						return nil
-					default:
-						return diag.Diagnostics{diag.Diagnostic{
-							Severity: diag.Error,
-							Summary:  "'nic_model' has incorrect value",
-							Detail: fmt.Sprintf(
-								"'nic_model' must be one of %s, %s or %s",
-								upcloud.NICModelE1000,
-								upcloud.NICModelVirtio,
-								upcloud.NICModelRTL8139),
-						}}
-					}
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						upcloud.NICModelE1000,
+						upcloud.NICModelVirtio,
+						upcloud.NICModelRTL8139,
+					),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"tags": {
+			"tags": schema.SetAttribute{
 				Description: "The server related tags",
-				Type:        schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
-				Optional: true,
+				Validators: []validator.Set{
+					noDuplicateTagsValidator{},
+				},
 			},
-			"host": {
+			"host": schema.Int64Attribute{
 				Description: "Use this to start the VM on a specific host. Refers to value from host -attribute. Only available for private cloud hosts",
-				Type:        schema.TypeInt,
 				Optional:    true,
 			},
-			"network_interface": {
-				Type: schema.TypeList,
+			"labels": utils.LabelsAttribute("server"),
+			"user_data": schema.StringAttribute{
+				Description: "Defines URL for a server setup script, or the script body itself",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"plan": schema.StringAttribute{
+				Description: "The pricing plan used for the server. You can list available server plans with `upctl server plans`",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(
+						path.MatchRoot("cpu"),
+						path.MatchRoot("mem"),
+					),
+				},
+			},
+			"boot_order": schema.StringAttribute{
+				Description: "The boot device order, `cdrom`|`disk`|`network` or comma separated combination of those values. Defaults to `disk`",
+				Computed:    true,
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"network_interface": schema.ListNestedBlock{
 				Description: `One or more blocks describing the network interfaces of the server.
 
     In addition to list order, the configured network interfaces are matched to the server's actual network interfaces by ` + "`" + `index` + "`" + ` and ` + "`" + `ip_address` + "`" + ` fields. This is to avoid public and utility network interfaces being re-assigned when the server is updated. This might result to inaccurate diffs in the plan, when interfaces are re-ordered or when interface is removed from the middle of the list.
 
     We recommend explicitly setting the value for ` + "`" + `index` + "`" + ` in configuration, when re-ordering interfaces or when removing interface from middle of the list.`,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"index": {
-							Type:         schema.TypeInt,
-							Description:  "The interface index.",
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntAtLeast(1),
-						},
-						"ip_address_family":   schemaIPAddressFamily("The type of the primary IP address of this interface (one of `IPv4` or `IPv6`)."),
-						"ip_address":          schemaIPAddress("The assigned primary IP address."),
-						"ip_address_floating": schemaIPAddressFloating("`true` indicates that the primary IP address is a floating IP address."),
-						"additional_ip_address": {
-							Type:        schema.TypeSet,
-							Description: "0-4 blocks of additional IP addresses to assign to this interface. Allowed only with network interfaces of type `private`",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"index": schema.Int64Attribute{
+							Description: "The interface index.",
 							Optional:    true,
-							MaxItems:    4,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"ip_address_family":   schemaIPAddressFamily("The type of this additional IP address of this interface (one of `IPv4` or `IPv6`)."),
-									"ip_address":          schemaIPAddress("The assigned additional IP address."),
-									"ip_address_floating": schemaIPAddressFloating("`true` indicates that the additional IP address is a floating IP address."),
+							Computed:    true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
+							Validators: []validator.Int64{
+								int64validator.AtLeast(1),
+							},
+						},
+						"ip_address_family":   attributeIPAddressFamily("The type of the primary IP address of this interface (one of `IPv4` or `IPv6`)."),
+						"ip_address":          attributeIPAddress("The primary IP address of this interface."),
+						"ip_address_floating": attributeIPAddressFloating("`true` indicates that the primary IP address is a floating IP address."),
+						"mac_address": schema.StringAttribute{
+							Description: "The MAC address of the interface.",
+							Computed:    true,
+						},
+						"type": schema.StringAttribute{
+							Description: "Network interface type. For private network interfaces, a network must be specified with an existing network id.",
+							Required:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									upcloud.NetworkTypePrivate,
+									upcloud.NetworkTypeUtility,
+									upcloud.NetworkTypePublic,
+								),
+							},
+						},
+						"network": schema.StringAttribute{
+							Description: "The UUID of the network to attach this interface to. Required for private network interfaces.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"source_ip_filtering": schema.BoolAttribute{
+							Description: "`true` if source IP should be filtered.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(true),
+						},
+						"bootable": schema.BoolAttribute{
+							Description: "`true` if this interface should be used for network booting.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"additional_ip_address": schema.SetNestedBlock{
+							Description: "0-4 blocks of additional IP addresses to assign to this interface. Allowed only with network interfaces of type `private`",
+							Validators: []validator.Set{
+								setvalidator.SizeAtMost(4),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"ip_address_family":   attributeIPAddressFamily("The type of the additional IP address of this interface (one of `IPv4` or `IPv6`)."),
+									"ip_address":          attributeIPAddress("An additional IP address for this interface."),
+									"ip_address_floating": attributeIPAddressFloating("`true` indicates that the additional IP address is a floating IP address."),
 								},
 							},
 						},
-						"mac_address": {
-							Type:        schema.TypeString,
-							Description: "The assigned MAC address.",
+					},
+				},
+			},
+			"storage_devices": schema.SetNestedBlock{
+				Description: "A set of storage devices associated with the server",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"address": schema.StringAttribute{
+							Description: "The device address the storage will be attached to (`scsi`|`virtio`|`ide`). Leave `address_position` field empty to auto-select next available address from that bus.",
 							Computed:    true,
-						},
-						"type": {
-							Type:        schema.TypeString,
-							Description: "Network interface type. For private network interfaces, a network must be specified with an existing network id.",
-							Required:    true,
-							ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
-								switch v.(string) {
-								case upcloud.NetworkTypePrivate, upcloud.NetworkTypeUtility, upcloud.NetworkTypePublic:
-									return nil
-								default:
-									return diag.Diagnostics{diag.Diagnostic{
-										Severity: diag.Error,
-										Summary:  "'type' has incorrect value",
-										Detail: fmt.Sprintf(
-											"'type' must be one of %s, %s or %s",
-											upcloud.NetworkTypePrivate,
-											upcloud.NetworkTypePublic,
-											upcloud.NetworkTypeUtility),
-									}}
-								}
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("scsi", "virtio", "ide"),
 							},
 						},
-						"network": {
-							Type:        schema.TypeString,
-							Description: "The unique ID of a network to attach this network to.",
-							Optional:    true,
-							Computed:    true,
-						},
-						"source_ip_filtering": {
-							Type:        schema.TypeBool,
-							Description: "`true` if source IP should be filtered.",
-							Optional:    true,
-							Default:     true,
-						},
-						"bootable": {
-							Type:        schema.TypeBool,
-							Description: "`true` if this interface should be used for network booting.",
-							Optional:    true,
-							Default:     false,
-						},
-					},
-				},
-			},
-			"labels": utils.LabelsSchema("server"),
-			"user_data": {
-				Description: "Defines URL for a server setup script, or the script body itself",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-			},
-			"plan": {
-				Description: "The pricing plan used for the server. You can list available server plans with `upctl server plans`",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-			},
-			"storage_devices": {
-				Description: "A list of storage devices associated with the server",
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"address": {
-							Description:  "The device address the storage will be attached to (`scsi`|`virtio`|`ide`). Leave `address_position` field empty to auto-select next available address from that bus.",
-							Type:         schema.TypeString,
-							Computed:     true,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"scsi", "virtio", "ide"}, false),
-						},
-						"address_position": {
+						"address_position": schema.StringAttribute{
 							Description: "The device position in the given bus (defined via field `address`). Valid values for address `virtio` are `0-15` (`0`, for example). Valid values for `scsi` or `ide` are `0-1:0-1` (`0:0`, for example). Leave empty to auto-select next available address in the given bus.",
-							Type:        schema.TypeString,
 							Computed:    true,
 							Optional:    true,
 						},
-						"storage": {
-							Description: "A valid storage UUID",
-							Type:        schema.TypeString,
-							Required:    true,
+						"storage": schema.StringAttribute{
+							Description: "The UUID of the storage to attach to the server.",
+							Optional:    true,
 						},
-						"type": {
-							Description:  "The device type the storage will be attached as",
-							Type:         schema.TypeString,
-							Computed:     true,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"disk", "cdrom"}, false),
+						"type": schema.StringAttribute{
+							Description: "The device type the storage will be attached as",
+							Computed:    true,
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("disk", "cdrom"),
+							},
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					// compute a consistent hash for this TypeSet, mandatory
-					m := v.(map[string]interface{})
-					return schema.HashString(
-						fmt.Sprintf("%s-%s-%s", m["storage"].(string), m["address"].(string), m["address_position"].(string)),
-					)
-				},
 			},
-			"template": {
-				Description:  "Block describing the preconfigured operating system",
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				AtLeastOneOf: []string{"storage_devices", "template"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
+			"template": schema.ListNestedBlock{
+				Description: "Block describing the preconfigured operating system",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("storage_devices"),
+					),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
 							Description: "The unique identifier for the storage",
-							Type:        schema.TypeString,
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
-						"address": {
+						"address": schema.StringAttribute{
 							Description: "The device address the storage will be attached to (`scsi`|`virtio`|`ide`). Leave `address_position` field empty to auto-select next available address from that bus.",
-							Type:        schema.TypeString,
 							Computed:    true,
 							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
-						"address_position": {
+						"address_position": schema.StringAttribute{
 							Description: "The device position in the given bus (defined via field `address`). For example `0:0`, or `0`. Leave empty to auto-select next available address in the given bus.",
-							Type:        schema.TypeString,
 							Computed:    true,
 							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
-						"encrypt": {
+						"encrypt": schema.BoolAttribute{
 							Description: "Sets if the storage is encrypted at rest",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							ForceNew:    true,
-						},
-						"size": {
-							Description:  "The size of the storage in gigabytes",
-							Type:         schema.TypeInt,
-							Computed:     true,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(10, 2048),
-						},
-						// will be set to value matching the plan
-						"tier": {
-							Description: "The storage tier to use",
-							Type:        schema.TypeString,
 							Computed:    true,
+							Optional:    true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+								boolplanmodifier.RequiresReplace(),
+							},
 						},
-						"title": {
-							Description:  "A short, informative description",
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringLenBetween(0, 64),
+						"size": schema.Int64Attribute{
+							Description: "The size of the storage in gigabytes",
+							Optional:    true,
+							Computed:    true,
+							Validators: []validator.Int64{
+								int64validator.Between(10, 2048),
+							},
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 						},
-						"storage": {
+						"tier": schema.StringAttribute{
+							Description: "The storage tier to use.",
+							Computed:    true,
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"title": schema.StringAttribute{
+							Description: "A short, informative description",
+							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 255),
+							},
+						},
+						"storage": schema.StringAttribute{
 							Description: "A valid storage UUID or template name. You can list available public templates with `upctl storage list --public --template` and available private templates with `upctl storage list --template`.",
-							Type:        schema.TypeString,
-							ForceNew:    true,
-							Required:    true,
+							// TODO: validate isrequired
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
 						},
-						"backup_rule": storage.BackupRuleSchema(),
-						"filesystem_autoresize": {
+						"filesystem_autoresize": schema.BoolAttribute{
 							Description: `If set to true, provider will attempt to resize partition and filesystem when the size of template storage changes.
 							Please note that before the resize attempt is made, backup of the storage will be taken. If the resize attempt fails, the backup will be used
 							to restore the storage and then deleted. If the resize attempt succeeds, backup will be kept (unless delete_autoresize_backup option is set to true).
 							Taking and keeping backups incure costs.`,
-							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
 						},
-						"delete_autoresize_backup": {
+						"delete_autoresize_backup": schema.BoolAttribute{
 							Description: "If set to true, the backup taken before the partition and filesystem resize attempt will be deleted immediately after success.",
-							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     false,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
+					},
+					Blocks: map[string]schema.Block{
+						"backup_rule": storage.BackupRuleBlock(),
 					},
 				},
 			},
-			"login": {
+			"login": schema.SetNestedBlock{
 				Description: "Configure access credentials to the server",
-				Type:        schema.TypeSet,
-				ForceNew:    true,
-				MaxItems:    1,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"user": {
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"user": schema.StringAttribute{
 							Description: "Username to be create to access the server",
-							Type:        schema.TypeString,
 							Optional:    true,
 						},
-						"keys": {
+						"keys": schema.ListAttribute{
 							Description: "A list of ssh keys to access the server",
-							Type:        schema.TypeList,
+							ElementType: types.StringType,
 							Optional:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
-						"create_password": {
+						"create_password": schema.BoolAttribute{
 							Description: "Indicates a password should be create to allow access",
-							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     false,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
-						"password_delivery": {
-							Description:  "The delivery method for the server's root password (one of `none`, `email` or `sms`)",
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "none",
-							ValidateFunc: validation.StringInSlice([]string{"none", "email", "sms"}, false),
-						},
-					},
-				},
-			},
-			"simple_backup": {
-				Description:   simpleBackupDescription,
-				Type:          schema.TypeSet,
-				MaxItems:      1,
-				Optional:      true,
-				ConflictsWith: []string{"template.0.backup_rule"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"plan": {
-							Description:  "Simple backup plan. Accepted values: daily, dailies, weeklies, monthlies.",
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"daily", "dailies", "weeklies", "monthlies"}, false),
-						},
-						"time": {
-							Description:  "Time of the day at which backup will be taken. Should be provided in a hhmm format (e.g. 2230).",
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\d{4}$`), "Time must be 4 digits in a hhmm format"),
+						"password_delivery": schema.StringAttribute{
+							Description: "The delivery method for the server's root password (one of `none`, `email` or `sms`)",
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString("none"),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+							Validators: []validator.String{
+								stringvalidator.OneOf("none", "email", "sms"),
+							},
 						},
 					},
 				},
 			},
-			"boot_order": {
-				Description: "The boot device order, `cdrom`|`disk`|`network` or comma separated combination of those values. Defaults to `disk`",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+			"simple_backup": schema.SetNestedBlock{
+				Description: simpleBackupDescription,
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"plan": schema.StringAttribute{
+							Description: "Simple backup plan. Accepted values: daily, dailies, weeklies, monthlies.",
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("daily", "dailies", "weeklies", "monthlies"),
+							},
+						},
+						"time": schema.StringAttribute{
+							Description: "Time of the day at which backup will be taken. Should be provided in a hhmm format (e.g. 2230).",
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`^\d{4}$`), "Time must be 4 digits in a hhmm format"),
+							},
+						},
+					},
+				},
 			},
 		},
-		CustomizeDiff: customdiff.Sequence(
-			// Validate tags here, because in-schema validation is only available for primitive types
-			validateTagsChange,
-		),
 	}
 }
 
-func resourceServerStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	svc := meta.(*service.Service)
-	networking, err := svc.GetServerNetworks(ctx, &request.GetServerNetworksRequest{ServerUUID: rawState["id"].(string)})
-	if err != nil {
-		return rawState, err
-	}
-
-	if networking == nil {
-		return rawState, nil
-	}
-
-	rawInterfaces, ok := rawState["network_interface"].([]interface{})
-	if !ok {
-		return rawState, fmt.Errorf("network_interface not found in state")
-	}
-
-	if len(networking.Interfaces) != len(rawInterfaces) {
-		return rawState, fmt.Errorf("values for network_interface have been modified outside of Terraform, unable to migrate the state. correct the drift between state and the resource to continue")
-	}
-
-	for k, v := range rawInterfaces {
-		iface := v.(map[string]interface{})
-		index, err := getIndexFromNetworking(networking, iface)
-		if err != nil {
-			return rawState, err
-		}
-
-		iface["index"] = index
-		rawInterfaces[k] = iface
-	}
-
-	rawState["network_interface"] = rawInterfaces
-
-	return rawState, nil
+func (r *serverResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = r.getSchema(2)
 }
 
-func getIndexFromNetworking(networking *upcloud.Networking, iface map[string]interface{}) (int, error) {
+func (r *serverResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := r.getSchema(0)
+	schemaV1 := r.getSchema(1)
+	return map[int64]resource.StateUpgrader{
+		// Add index value to network interfaces.
+		0: {
+			PriorSchema: &schemaV0,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var data serverModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				uuid := data.ID.ValueString()
+				networking, err := r.client.GetServerNetworks(ctx, &request.GetServerNetworksRequest{ServerUUID: uuid})
+				if err != nil {
+					resp.Diagnostics.AddError("Failed to get server networks", err.Error())
+					return
+				}
+
+				if networking == nil {
+					resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+				}
+
+				var networkInterfaces []networkInterfaceModel
+				resp.Diagnostics.Append(data.NetworkInterfaces.ElementsAs(ctx, &networkInterfaces, false)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				if len(networking.Interfaces) != len(networkInterfaces) {
+					resp.Diagnostics.AddError("State is not up-to-date", "Network interfaces have been modified outside of Terraform, unable to migrate the state. Correct the drift between state and the resource to continue")
+					return
+				}
+
+				for i, iface := range networkInterfaces {
+					index, diags := getIndexFromNetworking(networking, iface)
+					resp.Diagnostics.Append(diags...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+
+					networkInterfaces[i].Index = types.Int64Value(int64(index))
+				}
+
+				var diags diag.Diagnostics
+				data.NetworkInterfaces, diags = types.ListValueFrom(ctx, data.NetworkInterfaces.ElementType(ctx), networkInterfaces)
+				resp.Diagnostics.Append(diags...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+			},
+		},
+		// Replace empty login username with null value.
+		1: {
+			PriorSchema: &schemaV1,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var data serverModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				if !data.Login.IsNull() {
+					var login []loginModel
+					resp.Diagnostics.Append(data.Login.ElementsAs(ctx, &login, false)...)
+
+					if login[0].User.ValueString() == "" {
+						login[0].User = types.StringNull()
+					}
+
+					data.Login, _ = types.SetValueFrom(ctx, data.Login.ElementType(ctx), login)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+			},
+		},
+	}
+}
+
+func getIndexFromNetworking(networking *upcloud.Networking, iface networkInterfaceModel) (index int, diags diag.Diagnostics) {
 	for _, n := range networking.Interfaces {
-		if n.Type == iface["type"].(string) && n.MAC == iface["mac_address"].(string) {
-			return n.Index, nil
+		if n.Type == iface.Type.ValueString() && n.MAC == iface.MACAddress.ValueString() {
+			index = n.Index
+			return
 		}
 	}
 
-	return 0, fmt.Errorf("unable to find index for interface %s", iface["mac_address"].(string))
+	diags.AddError("Unable to find index", fmt.Sprintf("Unable to find index for interface %s", iface.MACAddress.ValueString()))
+	return
 }
 
-func schemaIPAddressFamily(description string) *schema.Schema {
-	return &schema.Schema{
-		Type:             schema.TypeString,
-		Description:      description,
-		Optional:         true,
-		Default:          upcloud.IPAddressFamilyIPv4,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{upcloud.IPAddressFamilyIPv4, upcloud.IPAddressFamilyIPv6}, false)),
-	}
-}
-
-func schemaIPAddress(description string) *schema.Schema {
-	return &schema.Schema{
-		Type:             schema.TypeString,
-		Description:      description,
-		Optional:         true,
-		Computed:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.IsIPAddress),
+func attributeIPAddressFamily(description string) schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: description,
+		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(upcloud.IPAddressFamilyIPv4),
+		Validators: []validator.String{
+			stringvalidator.OneOf(
+				upcloud.IPAddressFamilyIPv4,
+				upcloud.IPAddressFamilyIPv6,
+			),
+		},
 	}
 }
 
-func schemaIPAddressFloating(description string) *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeBool,
-		Description: description,
-		Computed:    true,
+func attributeIPAddress(description string) schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: description,
+		Optional:            true,
+		Computed:            true,
+		Validators:          []validator.String{validatorutil.NewFrameworkStringValidator(validation.IsIPAddress)},
 	}
 }
 
-func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*service.Service)
-	diags := diag.Diagnostics{}
+func attributeIPAddressFloating(description string) schema.BoolAttribute {
+	return schema.BoolAttribute{
+		MarkdownDescription: description,
+		Computed:            true,
+	}
+}
 
-	if err := validatePlan(ctx, client, d.Get("plan").(string)); err != nil {
-		return diag.FromErr(err)
+func (r *serverResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	var plan *serverModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if plan == nil {
+		// Do not validate config for destroy plans.
+		return
 	}
 
-	if err := validateZone(ctx, client, d.Get("zone").(string)); err != nil {
-		return diag.FromErr(err)
-	}
+	var config serverModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
-	r, err := buildServerOpts(ctx, d, meta)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	resp.Diagnostics.Append(validatePlan(ctx, r.client, config.Plan)...)
+	resp.Diagnostics.Append(validateZone(ctx, r.client, config.Zone)...)
 
-	if _, ok := d.GetOk("title"); ok {
-		r.Title = d.Get("title").(string)
+	var state serverModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	resp.Diagnostics.Append(validateTagsChangeRequiresMainAccount(ctx, r.client, state.Tags, plan.Tags)...)
+}
+
+func setValues(ctx context.Context, data *serverModel, server *upcloud.ServerDetails) diag.Diagnostics {
+	var respDiagnostics, diags diag.Diagnostics
+
+	data.ID = types.StringValue(server.UUID)
+	data.Hostname = types.StringValue(server.Hostname)
+	data.Title = types.StringValue(server.Title)
+	data.Zone = types.StringValue(server.Zone)
+	data.CPU = types.Int64Value(int64(server.CoreNumber))
+	data.Mem = types.Int64Value(int64(server.MemoryAmount))
+
+	data.Labels, diags = types.MapValueFrom(ctx, types.StringType, utils.LabelsSliceToMap(server.Labels))
+	respDiagnostics.Append(diags...)
+
+	data.NICModel = types.StringValue(server.NICModel)
+	data.Timezone = types.StringValue(server.Timezone)
+	data.VideoModel = types.StringValue(server.VideoModel)
+	if !data.Metadata.IsNull() {
+		data.Metadata = types.BoolValue(server.Metadata.Bool())
+	}
+	data.Plan = types.StringValue(server.Plan)
+	data.BootOrder = types.StringValue(server.BootOrder)
+
+	if !data.Tags.IsNull() {
+		data.Tags, diags = types.SetValueFrom(ctx, data.Tags.ElementType(ctx), server.Tags)
+		respDiagnostics.Append(diags...)
 	} else {
-		r.Title = defaultTitleFromHostname(d.Get("hostname").(string))
-	}
-
-	serverDetails, err := client.CreateServer(ctx, r)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(serverDetails.UUID)
-	tflog.Info(ctx, "server created", map[string]interface{}{"title": serverDetails.Title, "uuid": serverDetails.UUID})
-
-	// set template id from the payload (if passed)
-	if _, ok := d.GetOk("template.0"); ok {
-		_ = d.Set("template", []map[string]interface{}{{
-			"id":                       serverDetails.StorageDevices[0].UUID,
-			"storage":                  d.Get("template.0.storage"),
-			"filesystem_autoresize":    d.Get("template.0.filesystem_autoresize"),
-			"delete_autoresize_backup": d.Get("template.0.delete_autoresize_backup"),
-		}})
-	}
-
-	// Add server tags
-	if tags, tagsExists := d.GetOk("tags"); tagsExists {
-		tags := utils.ExpandStrings(tags)
-		if err := addTags(ctx, client, serverDetails.UUID, tags); err != nil {
-			if errors.As(err, &tagsExistsWarning{}) {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  err.Error(),
-				})
-			} else {
-				return diag.FromErr(err)
-			}
-		}
-	}
-
-	_, err = client.WaitForServerState(ctx, &request.WaitForServerStateRequest{
-		UUID:         serverDetails.UUID,
-		DesiredState: upcloud.ServerStateStarted,
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return append(diags, resourceServerRead(ctx, d, meta)...)
-}
-
-func resourceServerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*service.Service)
-	diags := diag.Diagnostics{}
-
-	r := &request.GetServerDetailsRequest{
-		UUID: d.Id(),
-	}
-	server, err := client.GetServerDetails(ctx, r)
-	if err != nil {
-		return utils.HandleResourceError(d.Get("hostname").(string), d, err)
-	}
-	_ = d.Set("hostname", server.Hostname)
-	if server.Title != defaultTitleFromHostname(server.Hostname) {
-		_ = d.Set("title", server.Title)
-	} else {
-		_ = d.Set("title", nil)
-	}
-	_ = d.Set("zone", server.Zone)
-	_ = d.Set("cpu", server.CoreNumber)
-	_ = d.Set("mem", server.MemoryAmount)
-
-	_ = d.Set("labels", utils.LabelsSliceToMap(server.Labels))
-
-	_ = d.Set("nic_model", server.NICModel)
-	_ = d.Set("timezone", server.Timezone)
-	_ = d.Set("video_model", server.VideoModel)
-	_ = d.Set("metadata", server.Metadata.Bool())
-	_ = d.Set("plan", server.Plan)
-	_ = d.Set("boot_order", server.BootOrder)
-
-	// XXX: server.Tags returns an empty slice rather than nil when it's empty
-	if len(server.Tags) > 0 {
-		_ = d.Set("tags", server.Tags)
+		data.Tags = types.SetNull(data.Tags.ElementType(ctx))
 	}
 
 	// Only track server_group when it has been configured to avoid changes when server is attached to group via upcloud_server_group.members.
-	if _, ok := d.GetOk("server_group"); ok {
-		_ = d.Set("server_group", server.ServerGroup)
+	if !data.ServerGroup.IsNull() {
+		data.ServerGroup = types.StringValue(server.ServerGroup)
 	}
 
 	if server.Firewall == "on" {
-		_ = d.Set("firewall", true)
+		data.Firewall = types.BoolValue(true)
 	} else {
-		_ = d.Set("firewall", false)
+		data.Firewall = types.BoolValue(false)
 	}
+
 	if server.SimpleBackup != "no" {
-		p := strings.Split(server.SimpleBackup, ",")
-		simpleBackup := map[string]interface{}{
-			"time": p[0],
-			"plan": p[1],
+		parts := strings.Split(server.SimpleBackup, ",")
+		if n := len(parts); n != 2 {
+			diags.AddError("Invalid simple backup configuration", fmt.Sprintf("Expected 2 parts, got %d", n))
 		}
-
-		_ = d.Set("simple_backup", []interface{}{simpleBackup})
+		simpleBackup := []simpleBackupModel{
+			{
+				Time: types.StringValue(parts[0]),
+				Plan: types.StringValue(parts[1]),
+			},
+		}
+		data.SimpleBackup, diags = types.SetValueFrom(ctx, data.SimpleBackup.ElementType(ctx), simpleBackup)
+		respDiagnostics.Append(diags...)
 	}
 
-	var connIP string
-	n, ok := d.Get("network_interface.#").(int)
-	if !ok {
-		return diag.Errorf("unable to read network_interface count")
-	}
-	networkInterfaces := make([]map[string]interface{}, n)
-	for i := 0; i < n; i++ {
-		key := interfaceKey(i)
-		val, ok := d.Get(key).(map[string]interface{})
-		if !ok {
-			return diag.Errorf("unable to read '%s' value", key)
-		}
+	var networkInterfaces []networkInterfaceModel
 
+	// Handle current network interfaces
+	var prevNetworkInterfaces []networkInterfaceModel
+	handledInterfaces := make(map[int]bool)
+
+	respDiagnostics.Append(data.NetworkInterfaces.ElementsAs(ctx, &prevNetworkInterfaces, false)...)
+
+	for i, nic := range prevNetworkInterfaces {
 		var iface *upcloud.ServerInterface
-		if index := val["index"].(int); index == 0 && i < len(server.Networking.Interfaces) {
+		index := nic.Index.ValueInt64()
+		if index == 0 && i < len(server.Networking.Interfaces) {
 			iface = &server.Networking.Interfaces[i]
+			index = int64(iface.Index)
 		} else {
-			iface = findInterface(server.Networking.Interfaces, val["index"].(int))
+			iface = findInterface(server.Networking.Interfaces, int(index))
 		}
 		if iface == nil {
 			continue
 		}
 
-		ni := setInterfaceValues((*upcloud.Interface)(iface), val["ip_address"])
-		networkInterfaces[i] = ni
+		ni, diags := setInterfaceValues(ctx, (*upcloud.Interface)(iface), nic.IPAddress)
+		respDiagnostics.Append(diags...)
 
-		if iface.Type == upcloud.NetworkTypePublic &&
-			iface.IPAddresses[0].Family == upcloud.IPAddressFamilyIPv4 {
-			connIP = iface.IPAddresses[0].Address
+		networkInterfaces = append(networkInterfaces, ni)
+		handledInterfaces[int(index)] = true
+	}
+
+	// Handle new network interfaces
+	for _, iface := range server.Networking.Interfaces {
+		if handledInterfaces[iface.Index] {
+			continue
 		}
+
+		ni, diags := setInterfaceValues(ctx, (*upcloud.Interface)(&iface), types.StringNull())
+		respDiagnostics.Append(diags...)
+		networkInterfaces = append(networkInterfaces, ni)
 	}
 
-	if err := d.Set("network_interface", networkInterfaces); err != nil {
-		return diag.FromErr(err)
-	}
+	data.NetworkInterfaces, diags = types.ListValueFrom(ctx, data.NetworkInterfaces.ElementType(ctx), networkInterfaces)
+	respDiagnostics.Append(diags...)
 
-	storageDevices := []interface{}{}
+	var storageDevices []storageDeviceModel
+	template, diags := getTemplate(ctx, *data)
+	respDiagnostics.Append(diags...)
+
 	for _, serverStorage := range server.StorageDevices {
-		// the template is managed within the server
-		if serverStorage.UUID == d.Get("template.0.id") {
-			_ = d.Set("template", []map[string]interface{}{{
-				"address":          utils.StorageAddressFormat(serverStorage.Address),
-				"address_position": utils.StorageAddressPositionFormat(serverStorage.Address),
-				"id":               serverStorage.UUID,
-				"encrypt":          serverStorage.Encrypted.Bool(),
-				"size":             serverStorage.Size,
-				"title":            serverStorage.Title,
-				"storage":          d.Get("template.0.storage"),
-				"tier":             serverStorage.Tier,
-				// NOTE: backupRule cannot be derived from server.storageDevices payload, will not sync if changed elsewhere
-				"backup_rule": d.Get("template.0.backup_rule"),
-				// Those fields are not set anywhere in the API, they are just for internal TF use
-				"filesystem_autoresize":    d.Get("template.0.filesystem_autoresize"),
-				"delete_autoresize_backup": d.Get("template.0.delete_autoresize_backup"),
-			}})
+		if serverStorage.UUID == template.ID.ValueString() {
+			templates := []templateModel{
+				{
+					Address:         types.StringValue(utils.StorageAddressFormat(serverStorage.Address)),
+					AddressPosition: types.StringValue(utils.StorageAddressPositionFormat(serverStorage.Address)),
+					ID:              types.StringValue(serverStorage.UUID),
+					Encrypt:         types.BoolValue(serverStorage.Encrypted.Bool()),
+					Size:            types.Int64Value(int64(serverStorage.Size)),
+					Tier:            types.StringValue(serverStorage.Tier),
+					Title:           types.StringValue(serverStorage.Title),
+
+					// Passthrough values
+					Storage:                template.Storage,
+					BackupRule:             template.BackupRule,
+					FilesystemAutoresize:   template.FilesystemAutoresize,
+					DeleteAutoresizeBackup: template.DeleteAutoresizeBackup,
+				},
+			}
+			data.Template, diags = types.ListValueFrom(ctx, data.Template.ElementType(ctx), templates)
+			respDiagnostics.Append(diags...)
 		} else {
-			storageDevices = append(storageDevices, map[string]interface{}{
-				"address":          utils.StorageAddressFormat(serverStorage.Address),
-				"address_position": utils.StorageAddressPositionFormat(serverStorage.Address),
-				"storage":          serverStorage.UUID,
-				"type":             serverStorage.Type,
+			storageDevices = append(storageDevices, storageDeviceModel{
+				Address:         types.StringValue(utils.StorageAddressFormat(serverStorage.Address)),
+				AddressPosition: types.StringValue(utils.StorageAddressPositionFormat(serverStorage.Address)),
+				Storage:         types.StringValue(serverStorage.UUID),
+				Type:            types.StringValue(serverStorage.Type),
 			})
 		}
 	}
-	_ = d.Set("storage_devices", storageDevices)
 
-	// Initialize the connection information.
-	d.SetConnInfo(map[string]string{
-		"host":     connIP,
-		"password": "",
-		"type":     "ssh",
-		"user":     "root",
-	})
+	data.StorageDevices, diags = types.SetValueFrom(ctx, data.StorageDevices.ElementType(ctx), storageDevices)
+	respDiagnostics.Append(diags...)
 
-	return diags
+	return respDiagnostics
 }
 
-func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*service.Service)
-	diags := diag.Diagnostics{}
+func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data serverModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	planHasChange := d.HasChange("plan")
-	if planHasChange {
-		if err := validatePlan(ctx, client, d.Get("plan").(string)); err != nil {
-			return diag.FromErr(err)
-		}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	serverDetails, err := client.GetServerDetails(ctx, &request.GetServerDetailsRequest{
-		UUID: d.Id(),
-	})
-	if err != nil {
-		return diag.FromErr(err)
+	var labels map[string]string
+	if !data.Labels.IsNull() && !data.Labels.IsUnknown() {
+		resp.Diagnostics.Append(data.Labels.ElementsAs(ctx, &labels, false)...)
+	}
+	var labelsSlice upcloud.LabelSlice = utils.LabelsMapToSlice(labels)
+
+	title := data.Title.ValueString()
+	if title == "" {
+		title = defaultTitleFromHostname(data.Hostname.ValueString())
 	}
 
-	// Before stopping, validate network interface requests to avoid unnecessary server downtime
-	err = validateNetworkInterfaces(ctx, client, d)
-	if err != nil {
-		return diag.FromErr(err)
+	apiReq := &request.CreateServerRequest{
+		BootOrder:    data.BootOrder.ValueString(),
+		CoreNumber:   int(data.CPU.ValueInt64()),
+		Host:         int(data.Host.ValueInt64()),
+		Hostname:     data.Hostname.ValueString(),
+		Labels:       &labelsSlice,
+		MemoryAmount: int(data.Mem.ValueInt64()),
+		Metadata:     utils.AsUpCloudBoolean(data.Metadata),
+		NICModel:     data.NICModel.ValueString(),
+		Plan:         data.Plan.ValueString(),
+		ServerGroup:  data.ServerGroup.ValueString(),
+		TimeZone:     data.Timezone.ValueString(),
+		Title:        title,
+		UserData:     data.UserData.ValueString(),
+		VideoModel:   data.VideoModel.ValueString(),
+		Zone:         data.Zone.ValueString(),
 	}
 
-	// Stop the server if the requested changes require it
-	if d.HasChanges("cpu", "mem", "timezone", "nic_model", "video_model", "template.0.size", "storage_devices", "network_interface") || planHasChange {
-		err := utils.VerifyServerStopped(ctx, request.StopServerRequest{
-			UUID: d.Id(),
-		},
-			meta,
-		)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	r := &request.ModifyServerRequest{
-		UUID: d.Id(),
-	}
-
-	r.Hostname = d.Get("hostname").(string)
-	if d.HasChange("labels") {
-		r.Labels = buildLabels(d.Get("labels").(map[string]interface{}))
-	}
-
-	if attr, ok := d.GetOk("title"); ok {
-		r.Title = attr.(string)
-	} else {
-		r.Title = defaultTitleFromHostname(d.Get("hostname").(string))
-	}
-
-	if attr, ok := d.GetOk("timezone"); ok {
-		r.TimeZone = attr.(string)
-	}
-
-	if attr, ok := d.GetOk("video_model"); ok {
-		r.VideoModel = attr.(string)
-	}
-
-	if attr, ok := d.GetOk("nic_model"); ok {
-		r.NICModel = attr.(string)
-	}
-
-	r.Metadata = upcloud.FromBool(d.Get("metadata").(bool))
-
-	if d.Get("firewall").(bool) {
-		r.Firewall = "on"
-	} else {
-		r.Firewall = "off"
-	}
-
-	if d.HasChange("simple_backup") {
-		if sb, ok := d.GetOk("simple_backup"); ok {
-			// Special handling for a situation where user adds simple backup rule for the server
-			// and removes backup_rule from a template with one apply. This needs to be done
-			// to prevent backup rule conflict error. We do not need to check if user removed
-			// template backup rule from the config, because having it together with server
-			// simple backup is not allowed on schema level
-			// Also see notes for simple_backup block in server resource docs for more insight:
-			// https://github.com/UpCloudLtd/terraform-provider-upcloud/blob/master/docs/resources/server.md#nested-schema-for-simple_backup
-			if hasTemplateBackupRuleBeenReplacedWithSimpleBackups(d) {
-				templateID := d.Get("template.0.id").(string)
-
-				tmpl, err := client.GetStorageDetails(ctx, &request.GetStorageDetailsRequest{UUID: templateID})
-				if err != nil {
-					return diag.FromErr(err)
-				}
-
-				if tmpl.BackupRule != nil && tmpl.BackupRule.Interval != "" {
-					r := &request.ModifyStorageRequest{
-						UUID:       templateID,
-						BackupRule: &upcloud.BackupRule{},
-					}
-
-					if _, err := client.ModifyStorage(ctx, r); err != nil {
-						return diag.FromErr(err)
-					}
-				}
-			}
-
-			simpleBackupAttrs := sb.(*schema.Set).List()[0].(map[string]interface{})
-			r.SimpleBackup = buildSimpleBackupOpts(simpleBackupAttrs)
+	if !data.Firewall.IsNull() {
+		if data.Firewall.ValueBool() {
+			apiReq.Firewall = "on"
 		} else {
-			r.SimpleBackup = "no"
+			apiReq.Firewall = "off"
 		}
 	}
 
-	if d.HasChanges("cpu", "mem") || planHasChange {
-		if plan, ok := d.GetOk("plan"); ok && plan.(string) != "custom" {
-			r.Plan = plan.(string)
-		} else {
-			r.CoreNumber = d.Get("cpu").(int)
-			r.MemoryAmount = d.Get("mem").(int)
-			r.Plan = "custom"
-		}
+	if !data.Login.IsNull() {
+		var login []loginModel
+		resp.Diagnostics.Append(data.Login.ElementsAs(ctx, &login, false)...)
+
+		loginOpts, deliveryMethod, diags := buildLoginOpts(ctx, login[0])
+		resp.Diagnostics.Append(diags...)
+
+		apiReq.LoginUser = loginOpts
+		apiReq.PasswordDelivery = deliveryMethod
 	}
 
-	if _, err := client.ModifyServer(ctx, r); err != nil {
-		return diag.FromErr(err)
+	if !data.SimpleBackup.IsNull() {
+		simpleBackup, diags := getSimpleBackup(ctx, data)
+		resp.Diagnostics.Append(diags...)
+
+		apiReq.SimpleBackup = buildSimpleBackupOpts(simpleBackup)
 	}
 
-	if d.HasChange("server_group") {
-		oldGroup, newGroup := d.GetChange("server_group")
-
-		err = removeServerFromGroup(ctx, client, d.Id(), oldGroup.(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		err = addServerToGroup(ctx, client, d.Id(), newGroup.(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("tags") {
-		oldTags, newTags := d.GetChange("tags")
-		if err := updateTags(
-			ctx,
-			client,
-			d.Id(),
-			utils.ExpandStrings(oldTags),
-			utils.ExpandStrings(newTags),
-		); err != nil {
-			if errors.As(err, &tagsExistsWarning{}) {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  err.Error(),
-				})
-			} else {
-				return diag.FromErr(err)
-			}
-		}
-	}
-
-	// handle the template
-	if d.HasChanges("template.0.title", "template.0.size", "template.0.backup_rule") {
-		template := d.Get("template.0").(map[string]interface{})
-		r := &request.ModifyStorageRequest{}
-
-		r.UUID = template["id"].(string)
-		r.Size = template["size"].(int)
-		r.Title = template["title"].(string)
-
-		if d.HasChange("template.0.backup_rule") && !hasTemplateBackupRuleBeenReplacedWithSimpleBackups(d) {
-			if backupRule, ok := d.GetOk("template.0.backup_rule.0"); ok {
-				rule := backupRule.(map[string]interface{})
-				r.BackupRule = storage.BackupRule(rule)
-			}
+	template, diags := getTemplate(ctx, data)
+	resp.Diagnostics.Append(diags...)
+	if template != nil {
+		title := template.Title.ValueString()
+		if title == "" {
+			title = fmt.Sprintf("terraform-%s-disk", data.Hostname.ValueString())
 		}
 
-		storageDetails, err := client.ModifyStorage(ctx, r)
-		if err != nil {
-			return diag.FromErr(err)
+		storageDevice := request.CreateServerStorageDevice{
+			Action: "clone",
+			Address: buildStorageDeviceAddress(
+				template.Address.ValueString(),
+				template.AddressPosition.ValueString(),
+			),
+			Encrypted: upcloud.FromBool(template.Encrypt.ValueBool()),
+			Size:      int(template.Size.ValueInt64()),
+			Storage:   template.Storage.ValueString(),
+			Tier:      template.Tier.ValueString(),
+			Title:     title,
 		}
 
-		if d.HasChange("template.0.size") && d.Get("template.0.filesystem_autoresize").(bool) {
-			diags = append(diags, utils.AsSDKv2Diags(storage.ResizeStoragePartitionAndFs(
-				ctx,
-				client,
-				storageDetails.UUID,
-				d.Get("template.0.delete_autoresize_backup").(bool),
-			))...)
-		}
-	}
+		if !template.BackupRule.IsNull() {
+			var backupRules []storage.BackupRuleModel
+			resp.Diagnostics.Append(template.BackupRule.ElementsAs(ctx, &backupRules, false)...)
 
-	// should reattach if address changed
-	if d.HasChange("template.0.address") || d.HasChange("template.0.address_position") {
-		oldAddress, newAddress := d.GetChange("template.0.address")
-		oldPosition, newPosition := d.GetChange("template.0.address_position")
-
-		detachAddress := utils.StorageAddressFormat(oldAddress.(string))
-		if oldPosition.(string) != "" {
-			detachAddress = fmt.Sprintf(":%s", oldPosition.(string))
+			storageDevice.BackupRule = storage.BackupRule(backupRules[0])
 		}
 
-		if _, err := client.DetachStorage(ctx, &request.DetachStorageRequest{
-			ServerUUID: d.Id(),
-			Address:    detachAddress,
-		}); err != nil {
-			return diag.FromErr(err)
-		}
-
-		attachAddress := utils.StorageAddressFormat(newAddress.(string))
-		if newPosition.(string) != "" {
-			attachAddress = fmt.Sprintf(":%s", newPosition.(string))
-		}
-
-		if _, err := client.AttachStorage(ctx, &request.AttachStorageRequest{
-			Address:     attachAddress,
-			ServerUUID:  d.Id(),
-			StorageUUID: d.Get("template.0.id").(string),
-		}); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	// handle the other storage devices
-	if d.HasChange("storage_devices") {
-		o, n := d.GetChange("storage_devices")
-
-		// detach the devices that should be detached or should be re-attached with different parameters
-		for _, rawStorageDevice := range o.(*schema.Set).Difference(n.(*schema.Set)).List() {
-			storageDevice := rawStorageDevice.(map[string]interface{})
-			serverStorageDevice := serverDetails.StorageDevice(storageDevice["storage"].(string))
-			if serverStorageDevice == nil {
-				continue
-			}
-			if _, err := client.DetachStorage(ctx, &request.DetachStorageRequest{
-				ServerUUID: d.Id(),
-				Address:    serverStorageDevice.Address,
-			}); err != nil {
-				return diag.FromErr(err)
-			}
-
-			// Remove backup rule from the detached storage, if it was a result of simple backup setting
-			if _, ok := d.GetOk("simple_backup"); ok {
-				if _, err := client.ModifyStorage(ctx, &request.ModifyStorageRequest{
-					UUID:       serverStorageDevice.UUID,
-					BackupRule: &upcloud.BackupRule{},
-				}); err != nil {
-					return diag.FromErr(err)
-				}
-			}
-		}
-
-		// attach the storages that are new or have changed
-		for _, rawStorageDevice := range n.(*schema.Set).Difference(o.(*schema.Set)).List() {
-			storageDevice := rawStorageDevice.(map[string]interface{})
-			address := storageDevice["address"].(string)
-			position := storageDevice["address_position"].(string)
-			if position != "" {
-				address += fmt.Sprintf(":%s", position)
-			}
-			if _, err := client.AttachStorage(ctx, &request.AttachStorageRequest{
-				ServerUUID:  d.Id(),
-				Address:     address,
-				StorageUUID: storageDevice["storage"].(string),
-				Type:        storageDevice["type"].(string),
-			}); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-	}
-
-	if d.HasChange("network_interface") {
-		if err := updateServerNetworkInterfaces(ctx, client, d); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if err := utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: d.Id(), Host: d.Get("host").(int)}, meta); err != nil {
-		return diag.FromErr(err)
-	}
-
-	diags = append(diags, resourceServerRead(ctx, d, meta)...)
-
-	return diags
-}
-
-func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*service.Service)
-
-	var diags diag.Diagnostics
-
-	// Verify server is stopped before deletion
-	if err := utils.VerifyServerStopped(ctx, request.StopServerRequest{UUID: d.Id()}, meta); err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Delete tags that are not used by any other servers
-	if err := removeTags(ctx, client, d.Id(), utils.ExpandStrings(d.Get("tags"))); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "failed to delete tags that will be unused after server deletion",
-			Detail:   err.Error(),
-		})
-	}
-
-	// Delete server
-	deleteServerRequest := &request.DeleteServerRequest{
-		UUID: d.Id(),
-	}
-	tflog.Info(ctx, "deleting server", map[string]interface{}{"uuid": d.Id()})
-	if err := client.DeleteServer(ctx, deleteServerRequest); err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Delete server root disk
-	if template, ok := d.GetOk("template.0"); ok {
-		template := template.(map[string]interface{})
-		deleteStorageRequest := &request.DeleteStorageRequest{
-			UUID: template["id"].(string),
-		}
-		tflog.Info(ctx, "deleting server storage", map[string]interface{}{"storage_uuid": deleteStorageRequest.UUID})
-		if err := client.DeleteStorage(ctx, deleteStorageRequest); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	return diags
-}
-
-func buildServerOpts(ctx context.Context, d *schema.ResourceData, meta interface{}) (*request.CreateServerRequest, error) {
-	r := &request.CreateServerRequest{
-		Zone:     d.Get("zone").(string),
-		Hostname: d.Get("hostname").(string),
-	}
-
-	if attr, ok := d.GetOk("server_group"); ok {
-		r.ServerGroup = attr.(string)
-	}
-	if attr, ok := d.GetOk("firewall"); ok {
-		if attr.(bool) {
-			r.Firewall = "on"
-		} else {
-			r.Firewall = "off"
-		}
-	}
-	if attr, ok := d.GetOk("labels"); ok {
-		r.Labels = buildLabels(attr.(map[string]interface{}))
-	}
-	if attr, ok := d.GetOk("metadata"); ok {
-		if attr.(bool) {
-			r.Metadata = upcloud.True
-		} else {
-			r.Metadata = upcloud.False
-		}
-	}
-	if attr, ok := d.GetOk("cpu"); ok {
-		r.CoreNumber = attr.(int)
-	}
-	if attr, ok := d.GetOk("mem"); ok {
-		r.MemoryAmount = attr.(int)
-	}
-	if attr, ok := d.GetOk("timezone"); ok {
-		r.TimeZone = attr.(string)
-	}
-	if attr, ok := d.GetOk("video_model"); ok {
-		r.VideoModel = attr.(string)
-	}
-	if attr, ok := d.GetOk("nic_model"); ok {
-		r.NICModel = attr.(string)
-	}
-	if attr, ok := d.GetOk("user_data"); ok {
-		r.UserData = attr.(string)
-	}
-	if attr, ok := d.GetOk("plan"); ok {
-		r.Plan = attr.(string)
-	}
-	if attr, ok := d.GetOk("boot_order"); ok {
-		r.BootOrder = attr.(string)
-	}
-	if attr, ok := d.GetOk("simple_backup"); ok {
-		simpleBackupAttrs := attr.(*schema.Set).List()[0].(map[string]interface{})
-		r.SimpleBackup = buildSimpleBackupOpts(simpleBackupAttrs)
-	}
-	if login, ok := d.GetOk("login"); ok {
-		loginOpts, deliveryMethod, err := buildLoginOpts(login)
-		if err != nil {
-			return nil, err
-		}
-		r.LoginUser = loginOpts
-		r.PasswordDelivery = deliveryMethod
-	}
-
-	r.Host = d.Get("host").(int)
-
-	if template, ok := d.GetOk("template.0"); ok {
-		template := template.(map[string]interface{})
-		if template["title"].(string) == "" {
-			template["title"] = fmt.Sprintf("terraform-%s-disk", r.Hostname)
-		}
-		address := template["address"].(string)
-		position := template["address_position"].(string)
-		if position != "" {
-			address += fmt.Sprintf(":%s", position)
-		}
-		serverStorageDevice := request.CreateServerStorageDevice{
-			Action:    "clone",
-			Address:   address,
-			Encrypted: upcloud.FromBool(template["encrypt"].(bool)),
-			Size:      template["size"].(int),
-			Storage:   template["storage"].(string),
-			Title:     template["title"].(string),
-		}
-		if attr, ok := d.GetOk("template.0.backup_rule.0"); ok {
-			serverStorageDevice.BackupRule = storage.BackupRule(attr.(map[string]interface{}))
-		}
-		if source := template["storage"].(string); source != "" {
+		if source := template.Storage.ValueString(); source != "" {
 			// Assume template name is given and attempt map name to UUID
 			if _, err := uuid.ParseUUID(source); err != nil {
-				l, err := meta.(*service.Service).GetStorages(ctx, &request.GetStoragesRequest{
+				l, err := r.client.GetStorages(ctx, &request.GetStoragesRequest{
 					Type: upcloud.StorageTypeTemplate,
 				})
 				if err != nil {
-					return nil, err
+					resp.Diagnostics.AddError(
+						"Unable to get storages",
+						utils.ErrorDiagnosticDetail(err),
+					)
+					return
 				}
 				for _, s := range l.Storages {
 					if s.Title == source {
@@ -1154,129 +982,458 @@ func buildServerOpts(ctx context.Context, d *schema.ResourceData, meta interface
 				}
 			}
 
-			serverStorageDevice.Storage = source
+			storageDevice.Storage = source
 		}
-		r.StorageDevices = append(r.StorageDevices, serverStorageDevice)
+
+		apiReq.StorageDevices = append(apiReq.StorageDevices, storageDevice)
 	}
 
-	if storageDevices, ok := d.GetOk("storage_devices"); ok {
-		storageDevices := storageDevices.(*schema.Set)
-		for _, storageDevice := range storageDevices.List() {
-			storageDevice := storageDevice.(map[string]interface{})
-			address := storageDevice["address"].(string)
-			position := storageDevice["address_position"].(string)
-			if position != "" {
-				address += fmt.Sprintf(":%s", position)
-			}
-			r.StorageDevices = append(r.StorageDevices, request.CreateServerStorageDevice{
-				Action:  "attach",
-				Address: address,
-				Type:    storageDevice["type"].(string),
-				Storage: storageDevice["storage"].(string),
+	if !data.StorageDevices.IsNull() {
+		var storageDevices []storageDeviceModel
+		resp.Diagnostics.Append(data.StorageDevices.ElementsAs(ctx, &storageDevices, false)...)
+
+		for _, storageDevice := range storageDevices {
+			apiReq.StorageDevices = append(apiReq.StorageDevices, request.CreateServerStorageDevice{
+				Action: "attach",
+				Address: buildStorageDeviceAddress(
+					storageDevice.Address.ValueString(),
+					storageDevice.AddressPosition.ValueString(),
+				),
+				Storage: storageDevice.Storage.ValueString(),
+				Type:    storageDevice.Type.ValueString(),
 			})
 		}
 	}
 
-	networking, err := buildNetworkOpts(d)
-	if err != nil {
-		return nil, err
-	}
+	networking, diags := buildNetworkOpts(ctx, data)
+	resp.Diagnostics.Append(diags...)
 
-	r.Networking = &request.CreateServerNetworking{
+	apiReq.Networking = &request.CreateServerNetworking{
 		Interfaces: networking,
 	}
 
-	return r, nil
-}
+	server, err := r.client.CreateServer(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create server",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
+	}
 
-func buildLabels(m map[string]interface{}) *upcloud.LabelSlice {
-	labels := upcloud.LabelSlice(utils.LabelsMapToSlice(m))
-	return &labels
-}
+	// Set template UUID as setValues uses that to determine if storage is a template.
+	if template != nil {
+		templates := []templateModel{
+			*template,
+		}
+		templates[0].ID = types.StringValue(server.StorageDevices[0].UUID)
+		data.Template, diags = types.ListValueFrom(ctx, data.Template.ElementType(ctx), templates)
+		resp.Diagnostics.Append(diags...)
+	}
 
-func buildSimpleBackupOpts(attrs map[string]interface{}) string {
-	if backupTime, ok := attrs["time"]; ok {
-		if plan, ok := attrs["plan"]; ok {
-			return fmt.Sprintf("%s,%s", backupTime, plan)
+	if !data.Tags.IsNull() {
+		tags, diags := getTags(ctx, data.Tags)
+		resp.Diagnostics.Append(diags...)
+
+		if err := addTags(
+			ctx,
+			r.client,
+			server.UUID,
+			tags,
+		); err != nil {
+			resp.Diagnostics.AddError("Unable to add server tags", utils.ErrorDiagnosticDetail(err))
 		}
 	}
 
-	return "no"
+	server, err = r.client.WaitForServerState(ctx, &request.WaitForServerStateRequest{
+		UUID:         server.UUID,
+		DesiredState: upcloud.ServerStateStarted,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error while waiting for server to be in started state",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(setValues(ctx, &data, server)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func buildLoginOpts(v interface{}) (*request.LoginUser, string, error) {
-	// Construct LoginUser struct from the schema
-	r := &request.LoginUser{}
-	e := v.(*schema.Set).List()[0]
-	m := e.(map[string]interface{})
+func (r *serverResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data serverModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	// Set username as is
-	r.Username = m["user"].(string)
-
-	// Set 'create_password' to "yes" or "no" depending on the bool value.
-	// Would be nice if the API would just get a standard bool str.
-	createPassword := "no"
-	b := m["create_password"].(bool)
-	if b {
-		createPassword = "yes"
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	r.CreatePassword = createPassword
 
-	// Handle SSH keys one by one
-	keys := make([]string, 0)
-	for _, k := range m["keys"].([]interface{}) {
-		key := k.(string)
-		keys = append(keys, key)
+	if data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+
+		return
 	}
-	r.SSHKeys = keys
 
-	// Define password delivery method none/email/sms
-	deliveryMethod := m["password_delivery"].(string)
+	server, err := r.client.GetServerDetails(ctx, &request.GetServerDetailsRequest{
+		UUID: data.ID.ValueString(),
+	})
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Unable to read server details",
+				utils.ErrorDiagnosticDetail(err),
+			)
+		}
+		return
+	}
 
-	return r, deliveryMethod, nil
+	resp.Diagnostics.Append(setValues(ctx, &data, server)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func buildNetworkOpts(d *schema.ResourceData) ([]request.CreateServerInterface, error) {
-	ifaces := []request.CreateServerInterface{}
+func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state, plan serverModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
-	niCount := d.Get("network_interface.#").(int)
-	for i := 0; i < niCount; i++ {
-		keyRoot := fmt.Sprintf("network_interface.%d.", i)
-		iface := request.CreateServerInterface{
-			Index: d.Get(keyRoot + "index").(int),
-			IPAddresses: []request.CreateServerIPAddress{
-				{
-					Family:  d.Get(keyRoot + "ip_address_family").(string),
-					Address: d.Get(keyRoot + "ip_address").(string),
-				},
-			},
-			Type: d.Get(keyRoot + "type").(string),
+	uuid := plan.ID.ValueString()
+	serverDetails, err := r.client.GetServerDetails(ctx, &request.GetServerDetailsRequest{
+		UUID: uuid,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to get server details", utils.ErrorDiagnosticDetail(err))
+		return
+	}
+
+	// Before stopping, validate network interface requests to avoid unnecessary server downtime
+	resp.Diagnostics.Append(validateNetworkInterfaces(ctx, r.client, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Stop the server if the requested changes require it
+	if !plan.CPU.Equal(state.CPU) ||
+		!plan.Mem.Equal(state.Mem) ||
+		!plan.Plan.Equal(state.Plan) ||
+		!plan.Timezone.Equal(state.Timezone) ||
+		!plan.VideoModel.Equal(state.VideoModel) ||
+		!plan.NICModel.Equal(state.NICModel) ||
+		!plan.Template.Equal(state.Template) ||
+		!plan.StorageDevices.Equal(state.StorageDevices) ||
+		!plan.NetworkInterfaces.Equal(state.NetworkInterfaces) {
+		err := utils.VerifyServerStopped(ctx, request.StopServerRequest{
+			UUID: uuid,
+		}, r.client)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to stop server", utils.ErrorDiagnosticDetail(err))
+			return
 		}
+	}
 
-		iface.SourceIPFiltering = upcloud.FromBool(d.Get(keyRoot + "source_ip_filtering").(bool))
-		iface.Bootable = upcloud.FromBool(d.Get(keyRoot + "bootable").(bool))
-
-		if v, ok := d.GetOk(keyRoot + "network"); ok {
-			iface.Network = v.(string)
+	firewall := ""
+	if !plan.Firewall.IsNull() && !plan.Firewall.IsUnknown() {
+		if plan.Firewall.ValueBool() {
+			firewall = "on"
+		} else {
+			firewall = "off"
 		}
+	}
 
-		if additionalIPAddresses, ok := d.GetOk(keyRoot + "additional_ip_address"); ok {
-			if iface.Type != upcloud.NetworkTypePrivate {
-				return nil, fmt.Errorf("additional_ip_address can only be set for private network interfaces")
+	var labels map[string]string
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		resp.Diagnostics.Append(plan.Labels.ElementsAs(ctx, &labels, false)...)
+	}
+	var labelsSlice upcloud.LabelSlice = utils.LabelsMapToSlice(labels)
+
+	apiReq := &request.ModifyServerRequest{
+		UUID: uuid,
+
+		CoreNumber:   int(plan.CPU.ValueInt64()),
+		Firewall:     firewall,
+		Hostname:     plan.Hostname.ValueString(),
+		Labels:       &labelsSlice,
+		MemoryAmount: int(plan.Mem.ValueInt64()),
+		Metadata:     utils.AsUpCloudBoolean(plan.Metadata),
+		NICModel:     plan.NICModel.ValueString(),
+		Plan:         plan.Plan.ValueString(),
+		TimeZone:     plan.Timezone.ValueString(),
+		Title:        plan.Title.ValueString(),
+		VideoModel:   plan.VideoModel.ValueString(),
+	}
+
+	templateState, diags := getTemplate(ctx, state)
+	resp.Diagnostics.Append(diags...)
+
+	templatePlan, diags := getTemplate(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+
+	if !plan.SimpleBackup.Equal(state.SimpleBackup) {
+		replaced, diags := hasTemplateBackupRuleBeenReplacedWithSimpleBackups(ctx, state, plan)
+		resp.Diagnostics.Append(diags...)
+		if replaced {
+			template, err := r.client.GetStorageDetails(ctx, &request.GetStorageDetailsRequest{UUID: templatePlan.ID.ValueString()})
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to get template storage details", utils.ErrorDiagnosticDetail(err))
+				return
 			}
 
-			for _, v := range additionalIPAddresses.(*schema.Set).List() {
-				ipAddress := v.(map[string]interface{})
-
-				iface.IPAddresses = append(iface.IPAddresses, request.CreateServerIPAddress{
-					Family:  ipAddress["ip_address_family"].(string),
-					Address: ipAddress["ip_address"].(string),
-				})
+			if template.BackupRule != nil && template.BackupRule.Interval != "" {
+				if _, err := r.client.ModifyStorage(ctx, &request.ModifyStorageRequest{
+					UUID:       template.UUID,
+					BackupRule: &upcloud.BackupRule{},
+				}); err != nil {
+					resp.Diagnostics.AddError("Unable to remove backup rule from template storage", utils.ErrorDiagnosticDetail(err))
+					return
+				}
 			}
 		}
 
-		ifaces = append(ifaces, iface)
+		simpleBackup, diags := getSimpleBackup(ctx, plan)
+		resp.Diagnostics.Append(diags...)
+		apiReq.SimpleBackup = buildSimpleBackupOpts(simpleBackup)
 	}
 
-	return ifaces, nil
+	if _, err := r.client.ModifyServer(ctx, apiReq); err != nil {
+		resp.Diagnostics.AddError("Unable to modify server", utils.ErrorDiagnosticDetail(err))
+		return
+	}
+
+	if !plan.ServerGroup.Equal(state.ServerGroup) {
+		err = removeServerFromGroup(ctx, r.client, uuid, state.ServerGroup.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to remove server from server group", utils.ErrorDiagnosticDetail(err))
+		}
+
+		err = addServerToGroup(ctx, r.client, uuid, plan.ServerGroup.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to add server to server group", utils.ErrorDiagnosticDetail(err))
+		}
+	}
+
+	if !plan.Tags.Equal(state.Tags) {
+		oldTags, diags := getTags(ctx, state.Tags)
+		resp.Diagnostics.Append(diags...)
+
+		newTags, diags := getTags(ctx, plan.Tags)
+		resp.Diagnostics.Append(diags...)
+
+		if err := updateTags(
+			ctx,
+			r.client,
+			uuid,
+			oldTags,
+			newTags,
+		); err != nil {
+			if errors.As(err, &tagsExistsWarning{}) {
+				resp.Diagnostics.AddWarning("Unable to create tags with matching letter casing", err.Error())
+			} else {
+				resp.Diagnostics.AddError("Unable to update server tags", utils.ErrorDiagnosticDetail(err))
+			}
+		}
+	}
+
+	if !templatePlan.Title.Equal(templateState.Title) ||
+		!templatePlan.Size.Equal(templateState.Size) ||
+		!templatePlan.BackupRule.Equal(templateState.BackupRule) {
+		apiReq := &request.ModifyStorageRequest{
+			UUID:  templatePlan.ID.ValueString(),
+			Size:  int(templatePlan.Size.ValueInt64()),
+			Title: templatePlan.Title.ValueString(),
+		}
+
+		replaced, diags := hasTemplateBackupRuleBeenReplacedWithSimpleBackups(ctx, state, plan)
+		resp.Diagnostics.Append(diags...)
+
+		if !templatePlan.BackupRule.Equal(templateState.BackupRule) && !replaced {
+			var backupRules []storage.BackupRuleModel
+			resp.Diagnostics.Append(templatePlan.BackupRule.ElementsAs(ctx, &backupRules, false)...)
+
+			apiReq.BackupRule = storage.BackupRule(backupRules[0])
+		}
+
+		storageDetails, err := r.client.ModifyStorage(ctx, apiReq)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to modify template storage", utils.ErrorDiagnosticDetail(err))
+		}
+
+		if !templatePlan.Size.Equal(templateState.Size) && templatePlan.FilesystemAutoresize.ValueBool() {
+			resp.Diagnostics.Append(storage.ResizeStoragePartitionAndFs(
+				ctx,
+				r.client,
+				storageDetails.UUID,
+				templatePlan.DeleteAutoresizeBackup.ValueBool(),
+			)...)
+		}
+	}
+
+	if !templatePlan.Address.Equal(templateState.Address) || !templatePlan.AddressPosition.Equal(templateState.AddressPosition) {
+		oldAddress := buildStorageDeviceAddress(
+			templateState.Address.ValueString(),
+			templateState.AddressPosition.ValueString(),
+		)
+		newAddress := buildStorageDeviceAddress(
+			templatePlan.Address.ValueString(),
+			templatePlan.AddressPosition.ValueString(),
+		)
+
+		if _, err := r.client.DetachStorage(ctx, &request.DetachStorageRequest{
+			ServerUUID: uuid,
+			Address:    oldAddress,
+		}); err != nil {
+			resp.Diagnostics.AddError("Unable to detach storage", utils.ErrorDiagnosticDetail(err))
+			return
+		}
+
+		if _, err := r.client.AttachStorage(ctx, &request.AttachStorageRequest{
+			Address:     newAddress,
+			ServerUUID:  uuid,
+			StorageUUID: templatePlan.ID.ValueString(),
+		}); err != nil {
+			resp.Diagnostics.AddError("Unable to attach storage", utils.ErrorDiagnosticDetail(err))
+			return
+		}
+	}
+
+	if !plan.StorageDevices.Equal(state.StorageDevices) {
+		var oldStorageDevices, newStorageDevices []storageDeviceModel
+		resp.Diagnostics.Append(state.StorageDevices.ElementsAs(ctx, &oldStorageDevices, false)...)
+		resp.Diagnostics.Append(plan.StorageDevices.ElementsAs(ctx, &newStorageDevices, false)...)
+
+		oldSet := newStorageDeviceSet(oldStorageDevices)
+		newSet := newStorageDeviceSet(newStorageDevices)
+
+		for _, storageDevice := range oldStorageDevices {
+			serverStorageDevice := serverDetails.StorageDevice(storageDevice.Storage.ValueString())
+			if newSet.includes(storageDevice) || serverStorageDevice == nil {
+				continue
+			}
+
+			if _, err := r.client.DetachStorage(ctx, &request.DetachStorageRequest{
+				ServerUUID: uuid,
+				Address:    serverStorageDevice.Address,
+			}); err != nil {
+				resp.Diagnostics.AddError("Unable to detach storage", utils.ErrorDiagnosticDetail(err))
+				return
+			}
+
+			// Remove backup rule from the detached storage, if it was a result of simple backup setting
+			if !plan.SimpleBackup.IsNull() {
+				if _, err := r.client.ModifyStorage(ctx, &request.ModifyStorageRequest{
+					UUID:       serverStorageDevice.UUID,
+					BackupRule: &upcloud.BackupRule{},
+				}); err != nil {
+					resp.Diagnostics.AddError("Unable to remove backup rule from storage", utils.ErrorDiagnosticDetail(err))
+					return
+				}
+			}
+		}
+
+		for _, storageDevice := range newStorageDevices {
+			if oldSet.includes(storageDevice) {
+				continue
+			}
+
+			if _, err := r.client.AttachStorage(ctx, &request.AttachStorageRequest{
+				ServerUUID: uuid,
+				Address: buildStorageDeviceAddress(
+					storageDevice.Address.ValueString(),
+					storageDevice.AddressPosition.ValueString(),
+				),
+				StorageUUID: storageDevice.Storage.ValueString(),
+				Type:        storageDevice.Type.ValueString(),
+			}); err != nil {
+				resp.Diagnostics.AddError("Unable to attach storage", utils.ErrorDiagnosticDetail(err))
+				return
+			}
+		}
+	}
+
+	if !plan.NetworkInterfaces.Equal(state.NetworkInterfaces) {
+		resp.Diagnostics.Append(updateServerNetworkInterfaces(ctx, r.client, &state, &plan)...)
+		if diags.HasError() {
+			return
+		}
+	}
+
+	server, err := utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: uuid, Host: int(plan.Host.ValueInt64())}, r.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to start server", utils.ErrorDiagnosticDetail(err))
+		return
+	}
+
+	resp.Diagnostics.Append(setValues(ctx, &plan, server)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func getTemplate(ctx context.Context, data serverModel) (*templateModel, diag.Diagnostics) {
+	var templates []templateModel
+	diags := data.Template.ElementsAs(ctx, &templates, false)
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if len(templates) == 1 {
+		return &templates[0], diags
+	}
+	return nil, diags
+}
+
+func getSimpleBackup(ctx context.Context, data serverModel) (*simpleBackupModel, diag.Diagnostics) {
+	var simpleBackup []simpleBackupModel
+	diags := data.SimpleBackup.ElementsAs(ctx, &simpleBackup, false)
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if len(simpleBackup) == 1 {
+		return &simpleBackup[0], diags
+	}
+	return nil, diags
+}
+
+func (r *serverResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data serverModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	uuid := data.ID.ValueString()
+	if err := utils.VerifyServerStopped(ctx, request.StopServerRequest{UUID: uuid}, r.client); err != nil {
+		resp.Diagnostics.AddError("Unable to stop server", utils.ErrorDiagnosticDetail(err))
+	}
+
+	var tags []string
+	resp.Diagnostics.Append(data.Tags.ElementsAs(ctx, &tags, false)...)
+
+	// Delete tags that are not used by any other servers
+	if err := removeTags(ctx, r.client, uuid, tags); err != nil {
+		resp.Diagnostics.AddWarning("Unable to delete tags that will be unused after server deletion", utils.ErrorDiagnosticDetail(err))
+	}
+
+	// Delete server
+	deleteServerRequest := &request.DeleteServerRequest{
+		UUID: uuid,
+	}
+	if err := r.client.DeleteServer(ctx, deleteServerRequest); err != nil {
+		resp.Diagnostics.AddError("Unable to delete server", utils.ErrorDiagnosticDetail(err))
+	}
+
+	template, diags := getTemplate(ctx, data)
+	resp.Diagnostics.Append(diags...)
+	// Delete server root disk
+	if template != nil {
+		deleteStorageRequest := &request.DeleteStorageRequest{
+			UUID: template.ID.ValueString(),
+		}
+		if err := r.client.DeleteStorage(ctx, deleteStorageRequest); err != nil {
+			resp.Diagnostics.AddError("Unable to delete server root disk", utils.ErrorDiagnosticDetail(err))
+		}
+	}
+}
+
+func (r *serverResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
-	"github.com/stretchr/testify/assert"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestServerDefaultTitle(t *testing.T) {
@@ -26,12 +25,12 @@ func TestServerDefaultTitle(t *testing.T) {
 }
 
 func TestBuildSimpleBackupOpts_basic(t *testing.T) {
-	attrs := map[string]interface{}{
-		"time": "2200",
-		"plan": "weeklies",
+	value := simpleBackupModel{
+		Time: types.StringValue("2200"),
+		Plan: types.StringValue("weeklies"),
 	}
 
-	sb := buildSimpleBackupOpts(attrs)
+	sb := buildSimpleBackupOpts(&value)
 	expected := "2200,weeklies"
 
 	if sb != expected {
@@ -41,26 +40,15 @@ func TestBuildSimpleBackupOpts_basic(t *testing.T) {
 }
 
 func TestBuildSimpleBackupOpts_withInvalidInput(t *testing.T) {
-	attrs := map[string]interface{}{
-		"time":     "2200",
-		"interval": "daily",
-		"retetion": 7,
+	value := simpleBackupModel{
+		Time: types.StringValue("2200"),
 	}
 
-	sb := buildSimpleBackupOpts(attrs)
+	sb := buildSimpleBackupOpts(&value)
 	expected := "no"
 
 	if sb != expected {
 		t.Logf("BuildSimpleBackuOpts produced unexpected value. Expected: %s, received: %s", expected, sb)
 		t.Fail()
 	}
-}
-
-func TestBuildLabels(t *testing.T) {
-	attr := map[string]interface{}{
-		"origin": "unit-test",
-	}
-
-	l := buildLabels(attr)
-	assert.Equal(t, &upcloud.LabelSlice{upcloud.Label{Key: "origin", Value: "unit-test"}}, l)
 }

--- a/internal/service/server/storages.go
+++ b/internal/service/server/storages.go
@@ -1,0 +1,32 @@
+package server
+
+import "fmt"
+
+type storageDeviceSet struct {
+	devices map[string]storageDeviceModel
+}
+
+func storageDeviceKey(device storageDeviceModel) string {
+	return fmt.Sprintf(
+		"%s-%s:%s",
+		device.Storage.ValueString(),
+		device.Address.ValueString(),
+		device.AddressPosition.ValueString(),
+	)
+}
+
+func newStorageDeviceSet(storageDevices []storageDeviceModel) *storageDeviceSet {
+	devices := make(map[string]storageDeviceModel)
+	for _, device := range storageDevices {
+		devices[storageDeviceKey(device)] = device
+	}
+
+	return &storageDeviceSet{
+		devices: devices,
+	}
+}
+
+func (s *storageDeviceSet) includes(device storageDeviceModel) bool {
+	_, ok := s.devices[storageDeviceKey(device)]
+	return ok
+}

--- a/internal/service/server/tags.go
+++ b/internal/service/server/tags.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
@@ -150,9 +149,9 @@ func getTagChange(oldTags, newTags []string) (tagsToAdd, tagsToDelete []string) 
 	return
 }
 
-func tagsHasChange(oldTags, newTags interface{}) bool {
+func tagsHasChange(oldTags, newTags []string) bool {
 	// Check how tags would change
-	toAdd, toDelete := getTagChange(utils.ExpandStrings(oldTags), utils.ExpandStrings(newTags))
+	toAdd, toDelete := getTagChange(oldTags, newTags)
 
 	// If no tags would be added or deleted, no change will be made
 	if len(toAdd) == 0 && len(toDelete) == 0 {

--- a/internal/service/storage/backup_rule.go
+++ b/internal/service/storage/backup_rule.go
@@ -4,7 +4,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkv2_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Lines > 1 should have one level of indentation to keep them under the right list item
@@ -45,45 +44,18 @@ func BackupRuleBlock() schema.ListNestedBlock {
 	}
 }
 
-func BackupRuleSchema() *sdkv2_schema.Schema {
-	return &sdkv2_schema.Schema{
-		Description: BackupRuleDescription,
-		Type:        sdkv2_schema.TypeList,
-		MaxItems:    1,
-		Optional:    true,
-		Elem: &sdkv2_schema.Resource{
-			Schema: map[string]*sdkv2_schema.Schema{
-				"interval": {
-					Description: "The weekday when the backup is created",
-					Type:        sdkv2_schema.TypeString,
-					Required:    true,
-				},
-				"time": {
-					Description: "The time of day when the backup is created",
-					Type:        sdkv2_schema.TypeString,
-					Required:    true,
-				},
-				"retention": {
-					Description: "The number of days before a backup is automatically deleted",
-					Type:        sdkv2_schema.TypeInt,
-					Required:    true,
-				},
-			},
-		},
-	}
-}
+func BackupRule(backupRule BackupRuleModel) *upcloud.BackupRule {
+	interval := backupRule.Interval.ValueString()
+	time := backupRule.Time.ValueString()
+	retention := int(backupRule.Retention.ValueInt64())
 
-func BackupRule(backupRule map[string]interface{}) *upcloud.BackupRule {
-	if interval, ok := backupRule["interval"]; ok {
-		if time, ok := backupRule["time"]; ok {
-			if retention, ok := backupRule["retention"]; ok {
-				return &upcloud.BackupRule{
-					Interval:  interval.(string),
-					Time:      time.(string),
-					Retention: retention.(int),
-				}
-			}
+	if interval != "" && time != "" && retention != 0 {
+		return &upcloud.BackupRule{
+			Interval:  interval,
+			Time:      time,
+			Retention: retention,
 		}
 	}
+
 	return &upcloud.BackupRule{}
 }

--- a/internal/service/storage/storage.go
+++ b/internal/service/storage/storage.go
@@ -495,7 +495,7 @@ func (r *storageResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Restart the attached server if it was stopped
 	if stopServer {
-		err := utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: storage.ServerUUIDs[0]}, r.client)
+		_, err := utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: storage.ServerUUIDs[0]}, r.client)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to restart attached server after resizing storage",
@@ -568,7 +568,7 @@ func (r *storageResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 			if strings.HasPrefix(storageDevice.Address, "ide") && serverDetails.State != upcloud.ServerStateStopped {
 				// No need to pass host explicitly here, as the server will be started on old host by default (for private clouds)
-				if err = utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: serverUUID}, r.client); err != nil {
+				if _, err = utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: serverUUID}, r.client); err != nil {
 					resp.Diagnostics.AddError(
 						"Unable to restart attached server after detaching storage",
 						utils.ErrorDiagnosticDetail(err),

--- a/internal/utils/default.go
+++ b/internal/utils/default.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ defaults.Bool = StaticUnknown{}
+
+// StaticUnknown sets an unknown default value. Terraform plugin framework should set null value in config to unknown value in plan, but if that does not happen, this can be used to force an unknown value to plan.
+type StaticUnknown struct{}
+
+func (d StaticUnknown) Description(_ context.Context) string {
+	return "unknown default value to be used when Terraform does not set a null value to unknown during planning"
+}
+
+func (d StaticUnknown) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d StaticUnknown) DefaultBool(_ context.Context, _ defaults.BoolRequest, resp *defaults.BoolResponse) {
+	resp.PlanValue = types.BoolUnknown()
+}

--- a/internal/utils/types.go
+++ b/internal/utils/types.go
@@ -20,6 +20,14 @@ func AsUpCloudBoolean(b types.Bool) upcloud.Boolean {
 	return upcloud.False
 }
 
+func AsTypesBool(b upcloud.Boolean) types.Bool {
+	if b.Empty() {
+		return types.BoolNull()
+	}
+
+	return types.BoolValue(b.Bool())
+}
+
 func AsBool(b upcloud.Boolean) types.Bool {
 	if b.Empty() {
 		return types.BoolPointerValue(nil)

--- a/internal/validator/domainname.go
+++ b/internal/validator/domainname.go
@@ -4,22 +4,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 var _ validator.String = isDomainNameValidator{}
 
-// isDomainNameValidator validates that the value of an int64 attribute is divisible by a given divisor.
-type isDomainNameValidator struct {
-	divisor int64
-}
+type isDomainNameValidator struct{}
 
 // Description describes the validation.
 func (v isDomainNameValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("value must be divisible by %d", v.divisor)
+	return "value must be a valid domain name"
 }
 
 // MarkdownDescription describes the validation in Markdown.
@@ -110,31 +105,4 @@ func ValidateDomainName(name string) error {
 	}
 
 	return nil
-}
-
-func ValidateDomainNameDiag(val interface{}, path cty.Path) diag.Diagnostics {
-	var diags diag.Diagnostics
-	name, ok := val.(string)
-
-	if !ok {
-		diags = append(diags, diag.Diagnostic{
-			Severity:      diag.Error,
-			Summary:       "Validation failed due to wrong type",
-			Detail:        "expected value to be a string",
-			AttributePath: path,
-		})
-		return diags
-	}
-
-	err := ValidateDomainName(name)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity:      diag.Error,
-			Summary:       "Validation failed",
-			Detail:        err.Error(),
-			AttributePath: path,
-		})
-	}
-
-	return diags
 }

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/network"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/networkpeering"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/router"
+	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/server"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/servergroup"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/storage"
 
@@ -173,6 +174,7 @@ func (p *upcloudProvider) Resources(_ context.Context) []func() resource.Resourc
 		network.NewNetworkResource,
 		networkpeering.NewNetworkPeeringResource,
 		router.NewRouterResource,
+		server.NewServerResource,
 		servergroup.NewServerGroupResource,
 		storage.NewStorageResource,
 		storage.NewStorageTemplateResource,

--- a/upcloud/resource_upcloud_server_group_test.go
+++ b/upcloud/resource_upcloud_server_group_test.go
@@ -67,7 +67,7 @@ func TestAccUpCloudServerGroup_ServerServerGroup(t *testing.T) {
 				Config: testDataStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(server(1), "server_group"),
-					resource.TestCheckResourceAttr(server(2), "server_group", ""),
+					resource.TestCheckNoResourceAttr(server(2), "server_group"),
 				),
 			},
 		},

--- a/upcloud/resource_upcloud_server_test.go
+++ b/upcloud/resource_upcloud_server_test.go
@@ -82,7 +82,7 @@ func TestUpcloudServer_minimal(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("upcloud_server.this", "zone", "fi-hel2"),
 					resource.TestCheckResourceAttr("upcloud_server.this", "hostname", "tf-acc-test-server-minimal"),
-					resource.TestCheckNoResourceAttr("upcloud_server.this", "tags"),
+					resource.TestCheckResourceAttr("upcloud_server.this", "tags.#", "0"),
 				),
 			},
 			{

--- a/upcloud/sdkv2_provider.go
+++ b/upcloud/sdkv2_provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/managedobjectstorage"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/network"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/objectstorage"
-	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/server"
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/service/tag"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
@@ -66,7 +65,6 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"upcloud_server":                                 server.ResourceServer(),
 			"upcloud_firewall_rules":                         firewall.ResourceFirewallRules(),
 			"upcloud_tag":                                    tag.ResourceTag(),
 			"upcloud_gateway":                                gateway.ResourceGateway(),

--- a/upcloud/testdata/upcloud_server/server_ifaces_s3.tf
+++ b/upcloud/testdata/upcloud_server/server_ifaces_s3.tf
@@ -19,7 +19,7 @@ resource "upcloud_network" "this" {
   }
 }
 
-# Nested field can not be set as unkown, so we need to remove the floating IP address to avoid data consistency error: https://github.com/hashicorp/terraform-plugin-sdk/issues/459
+# Nested field can not be set as unknown, so we need to remove the floating IP address to avoid data consistency error: https://github.com/hashicorp/terraform-plugin-sdk/issues/459
 # resource "upcloud_floating_ip_address" "this" {
 #   mac_address = upcloud_server.this.network_interface[1].mac_address
 # }


### PR DESCRIPTION
Also makes server template storage tier configurable (#536) and sets interface IP addresses as unknown (known after apply) in planning (#646).

- [x] Fix segfaults, data-consistency and other errors  
- [x] IP set to both `ip_address` and `additional_ip_addresses` if NIC type is private
- [x] Template details remain unknown after create
- [x] Validate plan and zone, currently commented out in [internal/service/server/server.go line 717](https://github.com/UpCloudLtd/terraform-provider-upcloud/blob/e34d1d58e6bf2e404b032f168bc76a8b4f50e6b5/internal/service/server/server.go#L717)
- [x] Compare IP against state instead of plan when determining if to update or replace network interface
- [x] Fix regressions caught by `TestUpcloudServer_minimal` and `TestAccUpcloudServerNetwork` tests