### PR TITLE
fix(kubernetes): remove extra waits from cluster and node-group delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- upcloud_kubernetes_cluster: update default plan to `dev-md`.
+- upcloud_kubernetes_\*: remove the extra waits from delete methods. The back-end side has been updated so that cluster does not return HTTP 404 response until it has been fully removed.
+
 ## [5.20.1] - 2025-02-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- upcloud_kubernetes_cluster: update default plan to `dev-md`.
+- upcloud_kubernetes_cluster: remove client side default value for plan and use default value defined by API instead.
 - upcloud_kubernetes_\*: remove the extra waits from delete methods. The back-end side has been updated so that cluster does not return HTTP 404 response until it has been fully removed.
 
 ## [5.20.1] - 2025-02-28

--- a/internal/service/kubernetes/cluster.go
+++ b/internal/service/kubernetes/cluster.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -117,7 +116,6 @@ func (r *kubernetesClusterResource) Schema(_ context.Context, _ resource.SchemaR
 				MarkdownDescription: planDescription,
 				Computed:            true,
 				Optional:            true,
-				Default:             stringdefault.StaticString("dev-md"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),

--- a/internal/service/kubernetes/cluster.go
+++ b/internal/service/kubernetes/cluster.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
 
@@ -118,7 +117,7 @@ func (r *kubernetesClusterResource) Schema(_ context.Context, _ resource.SchemaR
 				MarkdownDescription: planDescription,
 				Computed:            true,
 				Optional:            true,
-				Default:             stringdefault.StaticString("development"),
+				Default:             stringdefault.StaticString("dev-md"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
@@ -354,14 +353,6 @@ func (r *kubernetesClusterResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	resp.Diagnostics.Append(waitForClusterToBeDeleted(ctx, r.client, data.ID.ValueString())...)
-
-	// If there was an error during while waiting for the cluster to be deleted - just end the delete operation here
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Additionally wait some time so that all cleanup operations can finish
-	time.Sleep(time.Second * cleanupWaitTimeSeconds)
 }
 
 func (r *kubernetesClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -24,7 +24,7 @@ const (
 	networkDescription                  = "Network ID for the cluster to run in."
 	networkCIDRDescription              = "Network CIDR for the given network. Computed automatically."
 	nodeGroupNamesDescription           = "Names of the node groups configured to cluster"
-	planDescription                     = "The pricing plan used for the cluster. Default plan is `development`. You can list available plans with `upctl kubernetes plans`."
+	planDescription                     = "The pricing plan used for the cluster. You can list available plans with `upctl kubernetes plans`."
 	privateNodeGroupsDescription        = "Enable private node groups. Private node groups requires a network that is routed through NAT gateway."
 	stateDescription                    = "Operational state of the cluster."
 	versionDescription                  = "Kubernetes version ID, e.g. `1.29`. You can list available version IDs with `upctl kubernetes versions`."

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -27,7 +27,7 @@ const (
 	planDescription                     = "The pricing plan used for the cluster. You can list available plans with `upctl kubernetes plans`."
 	privateNodeGroupsDescription        = "Enable private node groups. Private node groups requires a network that is routed through NAT gateway."
 	stateDescription                    = "Operational state of the cluster."
-	versionDescription                  = "Kubernetes version ID, e.g. `1.29`. You can list available version IDs with `upctl kubernetes versions`."
+	versionDescription                  = "Kubernetes version ID, e.g. `1.30`. You can list available version IDs with `upctl kubernetes versions`."
 	zoneDescription                     = "Zone in which the Kubernetes cluster will be hosted, e.g. `de-fra1`. You can list available zones with `upctl zone list`."
 
 	resourceNameMaxLength = 63

--- a/internal/service/kubernetes/kubernetes.go
+++ b/internal/service/kubernetes/kubernetes.go
@@ -30,9 +30,8 @@ const (
 	versionDescription                  = "Kubernetes version ID, e.g. `1.29`. You can list available version IDs with `upctl kubernetes versions`."
 	zoneDescription                     = "Zone in which the Kubernetes cluster will be hosted, e.g. `de-fra1`. You can list available zones with `upctl zone list`."
 
-	cleanupWaitTimeSeconds = 240
-	resourceNameMaxLength  = 63
-	resourceNameRegexpStr  = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+	resourceNameMaxLength = 63
+	resourceNameRegexpStr = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 )
 
 var resourceNameRegexp = regexp.MustCompile(resourceNameRegexpStr)

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
 	validatorutil "github.com/UpCloudLtd/terraform-provider-upcloud/internal/validator"
@@ -507,14 +506,6 @@ func (r *kubernetesNodeGroupResource) Delete(ctx context.Context, req resource.D
 
 	// wait before continuing so that all nodes are destroyed
 	resp.Diagnostics.Append(waitForNodeGroupToBeDeleted(ctx, r.client, data.Cluster.ValueString(), data.Name.ValueString())...)
-
-	// If there was an error during while waiting for the node group to be deleted - just end the delete operation here
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Additionally wait some time so that all cleanup operations can finish
-	time.Sleep(time.Second * cleanupWaitTimeSeconds)
 }
 
 func (r *kubernetesNodeGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/upcloud/resource_upcloud_kubernetes_test.go
+++ b/upcloud/resource_upcloud_kubernetes_test.go
@@ -35,7 +35,7 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckTypeSetElemAttr(cName, "control_plane_ip_filter.*", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr(cName, "name", "tf-acc-test-k8s-cluster"),
-					resource.TestCheckResourceAttr(cName, "version", "1.29"),
+					resource.TestCheckResourceAttr(cName, "version", "1.30"),
 					resource.TestCheckResourceAttr(cName, "zone", "fi-hel2"),
 					resource.TestCheckResourceAttr(g1Name, "name", "small"),
 					resource.TestCheckResourceAttr(g2Name, "name", "medium"),
@@ -85,7 +85,7 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 				Config: testDataS2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(cName, "control_plane_ip_filter.#", "0"),
-					resource.TestCheckResourceAttr(cName, "version", "1.29"),
+					resource.TestCheckResourceAttr(cName, "version", "1.30"),
 					resource.TestCheckResourceAttr(g1Name, "node_count", "1"),
 					resource.TestCheckResourceAttr(g2Name, "node_count", "2"),
 				),


### PR DESCRIPTION
The back-end side has been updated so that cluster does not return HTTP 404 response until it has been fully removed. Also remove client side default value for plan and use default value defined by API instead.