### PR TITLE
feat(storage backup): Implementation of upcloud_storage_backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Display descriptive error message when credentials are not configured.
+
+### Added
+
 - Added upcloud_storage_backup resource that creates a backup of a storage resource
 
 ## [5.20.3] - 2025-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Added upcloud_storage_backup resource that creates a backup of a storage resource
+
 ## [5.21.0] - 2025-04-15
 
 ### Added
@@ -38,10 +42,6 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Display descriptive error message when credentials are not configured.
-
-### Added
-
-- Added upcloud_storage_backup resource that creates a backup of a storage resource
 
 ## [5.20.3] - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Display descriptive error message when credentials are not configured.
+- Added upcloud_storage_backup resource that creates a backup of a storage resource
 
 ## [5.20.3] - 2025-03-06
 

--- a/examples/resources/upcloud_storage_backup/resource.tf
+++ b/examples/resources/upcloud_storage_backup/resource.tf
@@ -1,0 +1,4 @@
+resource "upcloud_storage_backup" "backup_1" {
+  title          = "backup"
+  source_storage = "01185ec5-1b0b-4cbc-a968-eb920ac7572d"
+}

--- a/internal/service/storage/storage_backup.go
+++ b/internal/service/storage/storage_backup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -17,9 +16,8 @@ import (
 )
 
 var (
-	_ resource.Resource                = &storageBackupResource{}
-	_ resource.ResourceWithConfigure   = &storageBackupResource{}
-	_ resource.ResourceWithImportState = &storageBackupResource{}
+	_ resource.Resource              = &storageBackupResource{}
+	_ resource.ResourceWithConfigure = &storageBackupResource{}
 )
 
 type storageBackupResource struct {
@@ -120,7 +118,6 @@ func (r *storageBackupResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	// TODO: Do we have to remove the resource or do we have to log an error and return?
 	if data.SourceStorage.ValueString() == "" {
 		resp.State.RemoveResource(ctx)
 		return
@@ -214,6 +211,7 @@ func (r *storageBackupResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
+	// Do we want to delete the snapshot from the system or only make TF think it is deleted?
 	deleteStorageRequest := &request.DeleteStorageRequest{
 		UUID: backupID,
 	}
@@ -226,8 +224,4 @@ func (r *storageBackupResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	resp.State.RemoveResource(ctx)
-}
-
-func (r *storageBackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/service/storage/storage_backup.go
+++ b/internal/service/storage/storage_backup.go
@@ -1,0 +1,212 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	_ resource.Resource                = &storageBackupResource{}
+	_ resource.ResourceWithConfigure   = &storageBackupResource{}
+	_ resource.ResourceWithImportState = &storageBackupResource{}
+)
+
+type storageBackupResource struct {
+	client *service.Service
+}
+
+func NewStorageBackupResource() resource.Resource {
+	return &storageBackupResource{}
+}
+
+func (r *storageBackupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_storage_backup"
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *storageBackupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.client, resp.Diagnostics = utils.GetClientFromProviderData(req.ProviderData)
+}
+
+type storageBackupModel struct {
+	SourceStorage types.String `tfsdk:"source_storage"`
+	Title         types.String `tfsdk:"title"`
+	ID            types.String `tfsdk:"id"`
+	CreatedAt     types.String `tfsdk:"created_at"`
+}
+
+func (r *storageBackupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates an on-demand storage backup in UpCloud. To force a backup, change the backup title to a unique name",
+		Attributes: map[string]schema.Attribute{
+			"source_storage": schema.StringAttribute{
+				Required:    true,
+				Description: "The UUID of the storage to back up.",
+			},
+			"title": schema.StringAttribute{
+				Required:    true,
+				Description: "Title of the backup.",
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the created backup.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp of the backup creation.",
+			},
+		},
+	}
+}
+
+func (r *storageBackupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data storageBackupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create a backup
+	_, err := r.client.CreateBackup(ctx, &request.CreateBackupRequest{
+		UUID:  data.SourceStorage.ValueString(),
+		Title: data.Title.ValueString(),
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create storage backup", utils.ErrorDiagnosticDetail(err))
+		return
+	}
+
+	/*
+		// Format storage details as JSON for better readability
+		storageDetailsJSON, err := json.MarshalIndent(storageDetails, "", "  ")
+		if err != nil {
+			tflog.Error(ctx, "Failed to format storage details", map[string]interface{}{
+				"error": err.Error(),
+			})
+		} else {
+			tflog.Info(ctx, "Retrieved storage details:\n"+string(storageDetailsJSON))
+		}
+
+		tflog.Info(ctx, "--------------------------------------------------- 3")
+	*/
+
+	// Wait for backup to finish
+	_, err = r.client.WaitForStorageState(ctx, &request.WaitForStorageStateRequest{
+		UUID:         data.SourceStorage.ValueString(),
+		DesiredState: upcloud.StorageStateOnline,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Storage did not reach online state after backup process",
+			utils.ErrorDiagnosticDetail(err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	/*
+		// Check if backup already exists
+		backup, err := r.client.GetStorageDetails(ctx, &request.GetStorageDetailsRequest{
+			UUID: data.SourceStorage.ValueString(),
+		})
+
+		if err != nil {
+			resp.Diagnostics.AddError("Storage not found", utils.ErrorDiagnosticDetail(err))
+			return
+		}
+
+		// Format storage details as JSON for better readability
+		backupJSON, err := json.MarshalIndent(backup, "", "  ")
+		if err != nil {
+			tflog.Error(ctx, "Failed to format storage details", map[string]interface{}{
+				"error": err.Error(),
+			})
+		} else {
+			tflog.Info(ctx, "Retrieved storage details:\n"+string(backupJSON))
+		}
+	*/
+}
+
+func (r *storageBackupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data storageBackupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.SourceStorage.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Get storage details
+	storageDetails, err := r.client.GetStorageDetails(ctx, &request.GetStorageDetailsRequest{
+		UUID: data.SourceStorage.ValueString(),
+	})
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Unable to read storage details",
+				utils.ErrorDiagnosticDetail(err),
+			)
+		}
+		return
+	}
+
+	if data.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Check if backup exists
+	if !slices.Contains(storageDetails.BackupUUIDs, data.ID.ValueString()) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Get the Storage Backup details - IT DOES NOT EXIST
+	backup, err := r.client.GetStorageBackupDetails(ctx, &request.GetStorageBackupDetailsRequest{
+		UUID: data.ID.ValueString(),
+	})
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Unable to read backup storage details",
+				utils.ErrorDiagnosticDetail(err),
+			)
+		}
+		return
+	}
+
+	data.CreatedAt = types.StringValue(backup.Created)
+	data.Title = types.StringValue(backup.Title)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *storageBackupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// To be implemented
+}
+
+func (r *storageBackupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// To be implemented
+}
+
+func (r *storageBackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// To be implemented
+}

--- a/internal/service/storage/storage_backup.go
+++ b/internal/service/storage/storage_backup.go
@@ -210,7 +210,6 @@ func (r *storageBackupResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	// Do we want to delete the snapshot from the system or only make TF think it is deleted?
 	deleteStorageRequest := &request.DeleteStorageRequest{
 		UUID: backupID,
 	}

--- a/internal/service/storage/storage_backup.go
+++ b/internal/service/storage/storage_backup.go
@@ -46,7 +46,7 @@ type storageBackupModel struct {
 
 func (r *storageBackupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates an on-demand storage backup in UpCloud. To force a backup, change the backup title to a unique name",
+		Description: "Manages an on-demand storage backup.",
 		Attributes: map[string]schema.Attribute{
 			"source_storage": schema.StringAttribute{
 				Required:    true,

--- a/subcategories.json
+++ b/subcategories.json
@@ -23,6 +23,7 @@
     "server_group.md": "Servers",
     "storage.md": "Storage",
     "storage_template.md": "Storage",
+    "storage_backup.md": "Storage",
     "floating_ip_address.md": "Network",
     "gateway.md": "Network",
     "gateway_connection.md": "Network",

--- a/upcloud/provider.go
+++ b/upcloud/provider.go
@@ -181,6 +181,7 @@ func (p *upcloudProvider) Resources(_ context.Context) []func() resource.Resourc
 		servergroup.NewServerGroupResource,
 		storage.NewStorageResource,
 		storage.NewStorageTemplateResource,
+		storage.NewStorageBackupResource,
 	}
 }
 

--- a/upcloud/resource_upcloud_storage_test.go
+++ b/upcloud/resource_upcloud_storage_test.go
@@ -625,3 +625,33 @@ func testUpcloudStorageBackupConfig(backupTitle string) string {
 		}
 	`, backupTitle)
 }
+
+func TestAccUpCloudStorageBackup_import(t *testing.T) {
+	var backupDetails upcloud.StorageDetails
+
+	resourceName := "upcloud_storage_backup.this"
+	initialBackupTitle := "tf-acc-test-storage-backup-import"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		CheckDestroy:             testAccCheckStorageBackupDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create the backup resource
+			{
+				Config: testUpcloudStorageBackupConfig(initialBackupTitle),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageExists(resourceName, &backupDetails),
+					resource.TestCheckResourceAttr(resourceName, "title", initialBackupTitle),
+				),
+			},
+			// Step 2: Import the backup using its ID
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created_at", "source_storage"}, // optional: ignore if timestamp has formatting variation
+			},
+		},
+	})
+}

--- a/upcloud/resource_upcloud_storage_test.go
+++ b/upcloud/resource_upcloud_storage_test.go
@@ -550,3 +550,78 @@ func createTempImage() (string, *hash.Hash, error) {
 
 	return imagePath, &sum, nil
 }
+
+// Test Storage Backup Resource
+func TestAccUpCloudStorageBackup_basic(t *testing.T) {
+	var storageDetails upcloud.StorageDetails
+	var backupDetails upcloud.StorageDetails
+
+	resourceName := "upcloud_storage_backup.this"
+	storageName := "upcloud_storage.test"
+
+	// Define test title updates
+	initialBackupTitle := "tf-acc-test-storage-backup"
+	updatedBackupTitle := "tf-acc-test-storage-backup-updated"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		CheckDestroy:             testAccCheckStorageBackupDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create Storage and Backup
+			{
+				Config: testUpcloudStorageBackupConfig(initialBackupTitle),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckStorageExists(storageName, &storageDetails),
+					testAccCheckStorageExists(resourceName, &backupDetails),
+					resource.TestCheckResourceAttr(resourceName, "title", initialBackupTitle),
+				),
+			},
+			// Step 2: Update the Backup Title
+			{
+				Config: testUpcloudStorageBackupConfig(updatedBackupTitle),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "title", updatedBackupTitle),
+				),
+			},
+		},
+	})
+}
+
+// Ensure that storage backups are properly removed
+func testAccCheckStorageBackupDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "upcloud_storage_backup" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*service.Service)
+		_, err := client.GetStorageDetails(context.Background(), &request.GetStorageDetailsRequest{
+			UUID: rs.Primary.ID,
+		})
+
+		if err == nil {
+			return fmt.Errorf("Backup still exists: %s", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+// Generate Terraform Configuration for Storage & Backup
+func testUpcloudStorageBackupConfig(backupTitle string) string {
+	return fmt.Sprintf(`
+		// Step 1: Create a storage resource
+		resource "upcloud_storage" "test" {
+			size  = 10
+			tier  = "maxiops"
+			title = "tf-acc-test-storage"
+			zone  = "fi-hel1"
+		}
+
+		// Step 2: Create a backup from the storage
+		resource "upcloud_storage_backup" "this" {
+			source_storage = upcloud_storage.test.id
+			title          = "%s"
+		}
+	`, backupTitle)
+}

--- a/upcloud/testdata/upcloud_kubernetes/kubernetes_storage_encryption_s1.tf
+++ b/upcloud/testdata/upcloud_kubernetes/kubernetes_storage_encryption_s1.tf
@@ -36,5 +36,5 @@ resource "upcloud_kubernetes_node_group" "main" {
   cluster    = resource.upcloud_kubernetes_cluster.main.id
   node_count = 1
   name       = "small"
-  plan       = "1xCPU-1GB"
+  plan       = "1xCPU-2GB"
 }

--- a/upcloud/testdata/upcloud_kubernetes/kubernetes_storage_encryption_s2.tf
+++ b/upcloud/testdata/upcloud_kubernetes/kubernetes_storage_encryption_s2.tf
@@ -36,7 +36,7 @@ resource "upcloud_kubernetes_node_group" "main" {
   cluster    = resource.upcloud_kubernetes_cluster.main.id
   node_count = 1
   name       = "small"
-  plan       = "1xCPU-1GB"
+  plan       = "1xCPU-2GB"
 
   // This should not cause changes in the plan as the node group was created with clusters storage_encryption setting that matches the value defined here.
   storage_encryption = "data-at-rest"


### PR DESCRIPTION
- Added new storage backup resource: upcloud_storage_backup
- Added TestAccUpCloudStorageBackup_basic test
- Example:
```shell
resource "upcloud_storage_backup" "backup"{
  title = "backup13"
  source_storage = "0185b32e-41fd-46e4-b32e-a9d9028eaec6"
}
``` 
Notes: The resource manages one backup. Updates only changes the title. Deleting the resource from the configuration will delete the managed backup