### PR TITLE
feat(server): implement hot resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- upcloud_server: add `hot_resize` attribute, allowing plan changes without server restarts when supported by the platform. See [UpCloud documentation](https://upcloud.com/docs/guides/scale-cloud-servers-hot-resize/) for more information.
+
 ## [5.20.5] - 2025-04-10
 
 ### Changed

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -94,6 +94,7 @@ type serverModel struct {
 	Login             types.Set    `tfsdk:"login"`
 	SimpleBackup      types.Set    `tfsdk:"simple_backup"`
 	BootOrder         types.String `tfsdk:"boot_order"`
+	HotResize         types.Bool   `tfsdk:"hot_resize"`
 }
 
 type networkInterfaceModel struct {
@@ -304,6 +305,12 @@ func (r *serverResource) getSchema(version int64) schema.Schema {
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"hot_resize": schema.BoolAttribute{
+				Description: "If set to true, allows changing the server plan without requiring a reboot. This enables hot resizing of the server. If hot resizing fails, the apply operation will fail.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -853,6 +860,11 @@ func setValues(ctx context.Context, data *serverModel, server *upcloud.ServerDet
 	data.Plan = types.StringValue(server.Plan)
 	data.BootOrder = types.StringValue(server.BootOrder)
 
+	// Set hot_resize to false by default if not set
+	if data.HotResize.IsNull() {
+		data.HotResize = types.BoolValue(false)
+	}
+
 	if !data.Tags.IsNull() {
 		data.Tags, diags = types.SetValueFrom(ctx, data.Tags.ElementType(ctx), server.Tags)
 		respDiagnostics.Append(diags...)
@@ -1214,7 +1226,31 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	if changeRequiresServerStop(state, plan) {
+	// Check if plan is being changed and handle hot resize if enabled
+	if !plan.Plan.Equal(state.Plan) && plan.HotResize.ValueBool() {
+		// Attempt hot resize
+		hotResizeReq := &request.ModifyServerRequest{
+			UUID: uuid,
+		}
+
+		// Set the appropriate fields based on whether it's a custom plan
+		if plan.Plan.ValueString() == customPlanName {
+			hotResizeReq.CoreNumber = int(plan.CPU.ValueInt64())
+			hotResizeReq.MemoryAmount = int(plan.Mem.ValueInt64())
+		} else {
+			hotResizeReq.Plan = plan.Plan.ValueString()
+		}
+
+		_, err := r.client.ModifyServer(ctx, hotResizeReq)
+		if err != nil {
+			// If hot resize fails, return an error
+			resp.Diagnostics.AddError(
+				"Hot resize failed",
+				fmt.Sprintf("Unable to hot resize server: %s. Hot resize requires the server to be in a state where it can be resized without a reboot. If hot resize is not possible, set hot_resize = false to use the standard approach with server reboot.", utils.ErrorDiagnosticDetail(err)),
+			)
+			return
+		}
+	} else if changeRequiresServerStop(state, plan) {
 		err := utils.VerifyServerStopped(ctx, request.StopServerRequest{
 			UUID: uuid,
 		}, r.client)

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -1226,9 +1226,22 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Check if plan is being changed and handle hot resize if enabled
-	if !plan.Plan.Equal(state.Plan) && plan.HotResize.ValueBool() {
-		// Attempt hot resize
+	// Determine what changes are needed
+	planChanged := !plan.Plan.Equal(state.Plan)
+	hotResizeEnabled := plan.HotResize.ValueBool()
+	needsServerStop := changeRequiresServerStop(state, plan)
+
+	// Server stop is required for certain changes - this takes precedence over hot resize
+	if needsServerStop {
+		err := utils.VerifyServerStopped(ctx, request.StopServerRequest{
+			UUID: uuid,
+		}, r.client)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to stop server", utils.ErrorDiagnosticDetail(err))
+			return
+		}
+	} else if planChanged && hotResizeEnabled {
+		// Only attempt hot resize if no server stop is required
 		hotResizeReq := &request.ModifyServerRequest{
 			UUID: uuid,
 		}
@@ -1248,14 +1261,6 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 				"Hot resize failed",
 				fmt.Sprintf("Unable to hot resize server: %s. Hot resize requires the server to be in a state where it can be resized without a reboot. If hot resize is not possible, set hot_resize = false to use the standard approach with server reboot.", utils.ErrorDiagnosticDetail(err)),
 			)
-			return
-		}
-	} else if changeRequiresServerStop(state, plan) {
-		err := utils.VerifyServerStopped(ctx, request.StopServerRequest{
-			UUID: uuid,
-		}, r.client)
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to stop server", utils.ErrorDiagnosticDetail(err))
 			return
 		}
 	}

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -196,6 +196,30 @@ func TestChangeRequiresServerStop_withHotResize(t *testing.T) {
 			},
 			expectShutdown: false,
 		},
+		{
+			name: "Only hot_resize changing from true to false",
+			state: serverModel{
+				Plan:              types.StringValue("1xCPU-1GB"),
+				HotResize:         types.BoolValue(true),
+				Timezone:          defaultTimezone,
+				VideoModel:        defaultVideoModel,
+				NICModel:          defaultNICModel,
+				Template:          defaultTemplate,
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			plan: serverModel{
+				Plan:              types.StringValue("1xCPU-1GB"),
+				HotResize:         types.BoolValue(false),
+				Timezone:          defaultTimezone,
+				VideoModel:        defaultVideoModel,
+				NICModel:          defaultNICModel,
+				Template:          defaultTemplate,
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			expectShutdown: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -219,6 +220,128 @@ func TestChangeRequiresServerStop_withHotResize(t *testing.T) {
 				NetworkInterfaces: defaultNetworkInterfaces,
 			},
 			expectShutdown: false,
+		},
+		{
+			name: "Hot resize with plan change and network change - should require shutdown",
+			state: serverModel{
+				Plan:           types.StringValue("1xCPU-1GB"),
+				HotResize:      types.BoolValue(true),
+				Timezone:       defaultTimezone,
+				VideoModel:     defaultVideoModel,
+				NICModel:       defaultNICModel,
+				Template:       defaultTemplate,
+				StorageDevices: defaultStorageDevices,
+				NetworkInterfaces: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{},
+							map[string]attr.Value{},
+						),
+					},
+				),
+			},
+			plan: serverModel{
+				Plan:           types.StringValue("2xCPU-2GB"),
+				HotResize:      types.BoolValue(true),
+				Timezone:       defaultTimezone,
+				VideoModel:     defaultVideoModel,
+				NICModel:       defaultNICModel,
+				Template:       defaultTemplate,
+				StorageDevices: defaultStorageDevices,
+				NetworkInterfaces: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{},
+							map[string]attr.Value{},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{},
+							map[string]attr.Value{},
+						),
+					},
+				),
+			},
+			expectShutdown: true,
+		},
+		{
+			name: "Hot resize with plan change and storage change - should require shutdown",
+			state: serverModel{
+				Plan:              types.StringValue("1xCPU-1GB"),
+				HotResize:         types.BoolValue(true),
+				Timezone:          defaultTimezone,
+				VideoModel:        defaultVideoModel,
+				NICModel:          defaultNICModel,
+				Template:          defaultTemplate,
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			plan: serverModel{
+				Plan:       types.StringValue("2xCPU-2GB"),
+				HotResize:  types.BoolValue(true),
+				Timezone:   defaultTimezone,
+				VideoModel: defaultVideoModel,
+				NICModel:   defaultNICModel,
+				Template: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"size": types.Int64Type,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"size": types.Int64Type,
+							},
+							map[string]attr.Value{
+								"size": types.Int64Value(20),
+							},
+						),
+					},
+				),
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			expectShutdown: true,
+		},
+		{
+			name: "Hot resize with plan change and template change - should require shutdown",
+			state: serverModel{
+				Plan:              types.StringValue("1xCPU-1GB"),
+				HotResize:         types.BoolValue(true),
+				Timezone:          defaultTimezone,
+				VideoModel:        defaultVideoModel,
+				NICModel:          defaultNICModel,
+				Template:          defaultTemplate,
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			plan: serverModel{
+				Plan:       types.StringValue("2xCPU-2GB"),
+				HotResize:  types.BoolValue(true),
+				Timezone:   defaultTimezone,
+				VideoModel: defaultVideoModel,
+				NICModel:   defaultNICModel,
+				Template: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{},
+							map[string]attr.Value{},
+						),
+					},
+				),
+				StorageDevices:    defaultStorageDevices,
+				NetworkInterfaces: defaultNetworkInterfaces,
+			},
+			expectShutdown: true,
 		},
 	}
 

--- a/internal/service/server/utils.go
+++ b/internal/service/server/utils.go
@@ -104,6 +104,5 @@ func changeRequiresServerStop(state, plan serverModel) bool {
 		!plan.NICModel.Equal(state.NICModel) ||
 		!plan.Template.Equal(state.Template) ||
 		!plan.StorageDevices.Equal(state.StorageDevices) ||
-		!plan.NetworkInterfaces.Equal(state.NetworkInterfaces) ||
-		(state.HotResize.ValueBool() && !plan.HotResize.ValueBool()) // Only require server stop if hot_resize is changing from true to false
+		!plan.NetworkInterfaces.Equal(state.NetworkInterfaces)
 }


### PR DESCRIPTION
Add support for resizing server plans without requiring a reboot using the new `hot_resize` attribute. When enabled, this feature attempts to change the server plan without stopping the server. If hot resize fails, the apply operation will fail with a clear error message.

Key changes:
- Add `hot_resize` attribute to the server resource schema
- Implement logic to detect when server restart is required
- Update server modification code to attempt hot resize when applicable
- Add comprehensive tests for various hot resize scenarios
- Improve error handling to provide clear guidance when hot resize fails

This feature provides users with a way to change server plans with zero downtime when the hot resize feature is available. If the hot resize operation fails, users can set `hot_resize = false` to use the standard approach that includes a server restart.

### References

- https://developers.upcloud.com/1.3/8-servers/#modify-server
- https://upcloud.com/docs/guides/scale-cloud-servers-hot-resize/ 