### PR TITLE
chore(lint): enable nilness check and fix warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,8 @@ issues:
         - bodyclose
 
 linters-settings:
+  govet:
+    enable: [nilness]
   goconst:
     min-len: 5
   predeclared:

--- a/upcloud/resource_upcloud_objectstorage_test.go
+++ b/upcloud/resource_upcloud_objectstorage_test.go
@@ -486,9 +486,7 @@ func verifyObjectStorageDoesNotExist(name string) resource.TestCheckFunc {
 				return err
 			}
 
-			if err == nil {
-				return fmt.Errorf("[ERROR] found instance %s : %s that should have been deleted", name, rs.Primary.ID)
-			}
+			return fmt.Errorf("[ERROR] found instance %s : %s that should have been deleted", name, rs.Primary.ID)
 		}
 		return nil
 	}


### PR DESCRIPTION
Enable the nilness checker in govet and remove the unreachable code it identified in the object storage test.