### PR TITLE
fix(server): config loading in Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 - upcloud_server: add `hot_resize` attribute, allowing plan changes without server restarts when supported by the platform. See [UpCloud documentation](https://upcloud.com/docs/guides/scale-cloud-servers-hot-resize/) for more information.
+- upcloud_server: Correctly load configuration in Update method, fixing an issue where the `Host` field was not populated, potentially causing resource update failures.
 
 ## [5.20.5] - 2025-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 - upcloud_server: add `hot_resize` attribute, allowing plan changes without server restarts when supported by the platform. See [UpCloud documentation](https://upcloud.com/docs/guides/scale-cloud-servers-hot-resize/) for more information.
+
+### Fixed
+
 - upcloud_server: Correctly load configuration in Update method, fixing an issue where the `Host` field was not populated, potentially causing resource update failures.
 
 ## [5.20.5] - 2025-04-10

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -1207,7 +1207,7 @@ func (r *serverResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var config, state, plan serverModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 


### PR DESCRIPTION
The Update method was incorrectly attempting to load the Terraform configuration into the state variable instead of the config variable.

Consequently, further in the method this call has previously received an empty Host value:

```
	server, err := utils.VerifyServerStarted(ctx, request.StartServerRequest{UUID: uuid, Host: int(config.Host.ValueInt64())}, r.client)

```

