### PR TITLE
fix(server): assign and delete addresses on `additional_ip_address` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- upcloud_server: assign and delete IP addresses from network interface when there are changes in `additional_ip_address` blocks of private network interfaces.
+
 ## [5.23.1] - 2025-07-18
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1
-	github.com/UpCloudLtd/upcloud-go-api/v8 v8.21.0
+	github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1 h1:eTfQsv58ufALOk9BZ7WbS/i7pMUD11RnYYpRPsz0LdI=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1/go.mod h1:7OtVs2UqtfvjkC1HfE+Oud0MnbMv7qUWnbEgxnTAqts=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.21.0 h1:gPi3bLwNixV2xo3IFMhP65uOdJcE2KCooXQ5bzPJqEk=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.21.0/go.mod h1:ImDdnWfVVM6WCRTrskGhAw2W1cRwu5IEkBw+9UCzAv8=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0 h1:40GwpMlDJZbMlpIqA+1TF80U8Rfr6DbJEONft+1HU6A=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0/go.mod h1:ImDdnWfVVM6WCRTrskGhAw2W1cRwu5IEkBw+9UCzAv8=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/service/server/interface_test.go
+++ b/internal/service/server/interface_test.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,4 +56,64 @@ func TestResolveInterfaceIPAddress(t *testing.T) {
 		},
 	}, want)
 	assert.Error(t, err)
+}
+
+func TestShouldModifyInterface_addAdditionalIPAddress(t *testing.T) {
+	aaPlan := []additionalIPAddressModel{
+		{
+			IPAddress:         types.StringValue("10.100.10.3"),
+			IPAddressFamily:   types.StringValue("IPv4"),
+			IPAddressFloating: types.BoolValue(false),
+		},
+		{
+			IPAddress:         types.StringValue("10.100.10.4"),
+			IPAddressFamily:   types.StringValue("IPv4"),
+			IPAddressFloating: types.BoolValue(false),
+		},
+	}
+	aaType := types.ObjectType{
+		AttrTypes: additionalIPAddressModel{}.AttributeTypes(),
+	}
+	aaList, d := types.SetValueFrom(context.TODO(), aaType, aaPlan)
+	require.False(t, d.HasError())
+
+	assert.True(t, shouldModifyInterface(
+		networkInterfaceModel{
+			Index:                 types.Int64Value(1),
+			Type:                  types.StringValue("private"),
+			Network:               types.StringValue("111-222-333"),
+			IPAddress:             types.StringValue("10.100.10.2"),
+			IPAddressFamily:       types.StringValue("IPv4"),
+			AdditionalIPAddresses: aaList,
+		},
+		request.CreateNetworkInterfaceIPAddressSlice{
+			{
+				Family:  "IPv4",
+				Address: "10.100.10.2",
+			},
+			{
+				Family:  "IPv4",
+				Address: "10.100.10.3",
+			},
+			{
+				Family:  "IPv4",
+				Address: "10.100.10.4",
+			},
+		},
+		&upcloud.ServerInterface{
+			Index:   1,
+			Type:    upcloud.NetworkTypePrivate,
+			Network: "111-222-333",
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Family:  "IPv4",
+					Address: "10.100.10.2",
+				},
+				{
+					Family:  "IPv4",
+					Address: "10.100.10.3",
+				},
+			},
+		},
+	))
 }

--- a/upcloud/resource_upcloud_server_network_test.go
+++ b/upcloud/resource_upcloud_server_network_test.go
@@ -90,6 +90,7 @@ func TestAccUpcloudServerInterfaceMatching(t *testing.T) {
 					// Private IP will be re-assigned because it is not specified in the configuration
 					resource.TestCheckResourceAttr(this, "network_interface.3.index", "4"),
 					checkStringDoesNotChange(this, "network_interface.3.ip_address", &thisIP4),
+					resource.TestCheckResourceAttr(this, "network_interface.3.additional_ip_address.#", "0"),
 					resource.TestCheckResourceAttr(this, "network_interface.4.index", "5"),
 					checkStringDoesNotChange(this, "network_interface.4.ip_address", &thisIP5),
 					// IP family change
@@ -106,6 +107,7 @@ func TestAccUpcloudServerInterfaceMatching(t *testing.T) {
 					// Private IP will be re-assigned because it is not specified in the configuration
 					resource.TestCheckResourceAttr(this, "network_interface.2.index", "4"),
 					checkStringDoesNotChange(this, "network_interface.2.ip_address", &thisIP4),
+					resource.TestCheckResourceAttr(this, "network_interface.2.additional_ip_address.#", "1"),
 					resource.TestCheckResourceAttr(this, "network_interface.3.index", "5"),
 					checkStringDoesNotChange(this, "network_interface.3.ip_address", &thisIP5),
 					// IP family change

--- a/upcloud/testdata/upcloud_server/server_ifaces_s2.tf
+++ b/upcloud/testdata/upcloud_server/server_ifaces_s2.tf
@@ -52,6 +52,11 @@ resource "upcloud_server" "this" {
     index      = 4
     ip_address = "10.100.3.30"
     network    = upcloud_network.this.id
+
+    additional_ip_address {
+      ip_address        = "10.100.3.60"
+      ip_address_family = "IPv4"
+    }
   }
 
   network_interface {


### PR DESCRIPTION
Implements fix for #796 

- [x] Depends on https://github.com/UpCloudLtd/upcloud-go-api/pull/389
- [x] Use released version of Go SDK and run `go mod tidy`