### PR TITLE
feat(k8s): storage for cloud native and GPU plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- upcloud_kubernetes_node_group: support storage tier and size customisation for GPU and Cloud Native node groups.
+
 ## [5.23.4] - 2025-08-11
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1
-	github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0
+	github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1 h1:eTfQsv58ufALOk9BZ7WbS/i7pMUD11RnYYpRPsz0LdI=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1/go.mod h1:7OtVs2UqtfvjkC1HfE+Oud0MnbMv7qUWnbEgxnTAqts=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0 h1:40GwpMlDJZbMlpIqA+1TF80U8Rfr6DbJEONft+1HU6A=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.22.0/go.mod h1:ImDdnWfVVM6WCRTrskGhAw2W1cRwu5IEkBw+9UCzAv8=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0 h1:OWkIs5Z67jZJb9qNHNaNCl20vJaCIn9U1QnaRZE5grQ=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0/go.mod h1:ImDdnWfVVM6WCRTrskGhAw2W1cRwu5IEkBw+9UCzAv8=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/service/kubernetes/planmodifier.go
+++ b/internal/service/kubernetes/planmodifier.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -10,8 +11,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+const (
+	// Plan prefixes that support custom storage configuration
+	customPlanType        = "custom"
+	gpuPlanPrefix         = "GPU-"
+	cloudNativePlanPrefix = "CLOUDNATIVE-"
+)
+
 func getCustomPlanPlanModifier() planmodifier.List {
 	return &customPlanPlanModifier{}
+}
+
+func getGPUPlanPlanModifier() planmodifier.List {
+	return &gpuPlanPlanModifier{}
+}
+
+func getCloudNativePlanPlanModifier() planmodifier.List {
+	return &cloudNativePlanPlanModifier{}
 }
 
 type customPlanPlanModifier struct{}
@@ -20,7 +36,27 @@ func (d *customPlanPlanModifier) Description(_ context.Context) string {
 	return "Ensures that custom_plan block is set if plan field's value is custom and vice versa."
 }
 
+type gpuPlanPlanModifier struct{}
+
+func (d *gpuPlanPlanModifier) Description(_ context.Context) string {
+	return "Ensures that gpu_plan block is only used with GPU plans."
+}
+
+type cloudNativePlanPlanModifier struct{}
+
+func (d *cloudNativePlanPlanModifier) Description(_ context.Context) string {
+	return "Ensures that cloud_native_plan block is only used with Cloud Native plans."
+}
+
 func (d *customPlanPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *gpuPlanPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *cloudNativePlanPlanModifier) MarkdownDescription(ctx context.Context) string {
 	return d.Description(ctx)
 }
 
@@ -36,24 +72,77 @@ func (d *customPlanPlanModifier) PlanModifyList(ctx context.Context, req planmod
 	resp.Diagnostics.Append(diags...)
 }
 
+func (d *gpuPlanPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	var plan types.String
+	diags := req.Plan.GetAttribute(ctx, path.Root("plan"), &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = validateGPUPlan(plan.ValueString(), req.ConfigValue.IsNull())
+	resp.Diagnostics.Append(diags...)
+}
+
+func (d *cloudNativePlanPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	var plan types.String
+	diags := req.Plan.GetAttribute(ctx, path.Root("plan"), &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = validateCloudNativePlan(plan.ValueString(), req.ConfigValue.IsNull())
+	resp.Diagnostics.Append(diags...)
+}
+
 func validateCustomPlan(plan string, emptyCustomPlan bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if plan == "custom" && emptyCustomPlan {
+	// Only custom plans require and allow the custom_plan block
+	if plan == customPlanType && emptyCustomPlan {
 		diags.AddError(
 			"`custom_plan` field is required when using custom server plan for the node group",
 			"add `custom_plan` block or change to a non-custom plan",
 		)
-
 		return diags
 	}
 
-	if plan != "custom" && !emptyCustomPlan {
+	if plan != customPlanType && !emptyCustomPlan {
 		diags.AddError(
 			fmt.Sprintf("defining `custom_plan` block with %s plan is not supported", plan),
-			"use custom as the `plan` value or change to a non-custom plan",
+			"use `custom` plan or remove the `custom_plan` block",
 		)
+		return diags
+	}
 
+	return diags
+}
+
+func validateGPUPlan(plan string, emptyGPUPlan bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// GPU plan block is optional for GPU plans, not allowed for others
+	if !strings.HasPrefix(plan, gpuPlanPrefix) && !emptyGPUPlan {
+		diags.AddError(
+			fmt.Sprintf("defining `gpu_plan` block with %s plan is not supported", plan),
+			"use a GPU plan (GPU-*) or remove the `gpu_plan` block",
+		)
+		return diags
+	}
+
+	return diags
+}
+
+func validateCloudNativePlan(plan string, emptyCloudNativePlan bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Cloud Native plan block is optional for Cloud Native plans, not allowed for others
+	if !strings.HasPrefix(plan, cloudNativePlanPrefix) && !emptyCloudNativePlan {
+		diags.AddError(
+			fmt.Sprintf("defining `cloud_native_plan` block with %s plan is not supported", plan),
+			"use a Cloud Native plan (CLOUDNATIVE-*) or remove the `cloud_native_plan` block",
+		)
 		return diags
 	}
 

--- a/internal/service/kubernetes/planmodifier_test.go
+++ b/internal/service/kubernetes/planmodifier_test.go
@@ -26,13 +26,35 @@ func TestValidateCustomPlan(t *testing.T) {
 			},
 		},
 		{
-			name:            "Custom plan not allowed",
+			name:            "GPU plan cannot use custom_plan block",
+			planType:        "GPU-8xCPU-64GB-1xL40S",
+			emptyCustomPlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `custom_plan` block with GPU-8xCPU-64GB-1xL40S plan is not supported",
+					"use `custom` plan or remove the `custom_plan` block",
+				),
+			},
+		},
+		{
+			name:            "Cloud Native plan cannot use custom_plan block",
+			planType:        "CLOUDNATIVE-4xCPU-8GB",
+			emptyCustomPlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `custom_plan` block with CLOUDNATIVE-4xCPU-8GB plan is not supported",
+					"use `custom` plan or remove the `custom_plan` block",
+				),
+			},
+		},
+		{
+			name:            "Standard plan cannot use custom_plan block",
 			planType:        "standard",
 			emptyCustomPlan: false,
 			expectedDiags: diag.Diagnostics{
 				diag.NewErrorDiagnostic(
 					"defining `custom_plan` block with standard plan is not supported",
-					"use custom as the `plan` value or change to a non-custom plan",
+					"use `custom` plan or remove the `custom_plan` block",
 				),
 			},
 		},
@@ -43,7 +65,7 @@ func TestValidateCustomPlan(t *testing.T) {
 			expectedDiags:   diag.Diagnostics{},
 		},
 		{
-			name:            "No errors with non-custom plan",
+			name:            "No errors with non-custom plan without custom_plan block",
 			planType:        "standard",
 			emptyCustomPlan: true,
 			expectedDiags:   diag.Diagnostics{},
@@ -53,6 +75,108 @@ func TestValidateCustomPlan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diags := validateCustomPlan(tt.planType, tt.emptyCustomPlan)
+			require.True(t, diags.Equal(tt.expectedDiags))
+		})
+	}
+}
+
+func TestValidateGPUPlan(t *testing.T) {
+	tests := []struct {
+		name          string
+		planType      string
+		emptyGPUPlan  bool
+		expectedDiags diag.Diagnostics
+	}{
+		{
+			name:          "GPU plan can use gpu_plan block",
+			planType:      "GPU-8xCPU-64GB-1xL40S",
+			emptyGPUPlan:  false,
+			expectedDiags: diag.Diagnostics{},
+		},
+		{
+			name:          "GPU plan can omit gpu_plan block",
+			planType:      "GPU-8xCPU-64GB-1xL40S",
+			emptyGPUPlan:  true,
+			expectedDiags: diag.Diagnostics{},
+		},
+		{
+			name:         "Custom plan cannot use gpu_plan block",
+			planType:     "custom",
+			emptyGPUPlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `gpu_plan` block with custom plan is not supported",
+					"use a GPU plan (GPU-*) or remove the `gpu_plan` block",
+				),
+			},
+		},
+		{
+			name:         "Standard plan cannot use gpu_plan block",
+			planType:     "standard",
+			emptyGPUPlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `gpu_plan` block with standard plan is not supported",
+					"use a GPU plan (GPU-*) or remove the `gpu_plan` block",
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := validateGPUPlan(tt.planType, tt.emptyGPUPlan)
+			require.True(t, diags.Equal(tt.expectedDiags))
+		})
+	}
+}
+
+func TestValidateCloudNativePlan(t *testing.T) {
+	tests := []struct {
+		name                 string
+		planType             string
+		emptyCloudNativePlan bool
+		expectedDiags        diag.Diagnostics
+	}{
+		{
+			name:                 "Cloud Native plan can use cloud_native_plan block",
+			planType:             "CLOUDNATIVE-4xCPU-8GB",
+			emptyCloudNativePlan: false,
+			expectedDiags:        diag.Diagnostics{},
+		},
+		{
+			name:                 "Cloud Native plan can omit cloud_native_plan block",
+			planType:             "CLOUDNATIVE-4xCPU-8GB",
+			emptyCloudNativePlan: true,
+			expectedDiags:        diag.Diagnostics{},
+		},
+		{
+			name:                 "Custom plan cannot use cloud_native_plan block",
+			planType:             "custom",
+			emptyCloudNativePlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `cloud_native_plan` block with custom plan is not supported",
+					"use a Cloud Native plan (CLOUDNATIVE-*) or remove the `cloud_native_plan` block",
+				),
+			},
+		},
+		{
+			name:                 "GPU plan cannot use cloud_native_plan block",
+			planType:             "GPU-8xCPU-64GB-1xL40S",
+			emptyCloudNativePlan: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"defining `cloud_native_plan` block with GPU-8xCPU-64GB-1xL40S plan is not supported",
+					"use a Cloud Native plan (CLOUDNATIVE-*) or remove the `cloud_native_plan` block",
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := validateCloudNativePlan(tt.planType, tt.emptyCloudNativePlan)
 			require.True(t, diags.Equal(tt.expectedDiags))
 		})
 	}

--- a/upcloud/resource_upcloud_kubernetes_test.go
+++ b/upcloud/resource_upcloud_kubernetes_test.go
@@ -43,6 +43,7 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 	g1Name := "upcloud_kubernetes_node_group.g1"
 	g2Name := "upcloud_kubernetes_node_group.g2"
 	g3Name := "upcloud_kubernetes_node_group.g3"
+	g4Name := "upcloud_kubernetes_node_group.g4"
 
 	s1Version, s2Version := getLatestVersions(t)
 
@@ -108,6 +109,7 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 						"cores":        "1",
 						"memory":       "2048",
 						"storage_size": "25",
+						"storage_tier": "maxiops",
 					}),
 				),
 			},
@@ -128,6 +130,16 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 					resource.TestCheckResourceAttr(cName, "version", s2Version),
 					resource.TestCheckResourceAttr(g1Name, "node_count", "1"),
 					resource.TestCheckResourceAttr(g2Name, "node_count", "2"),
+
+					// Cloud Native plan node group checks
+					resource.TestCheckResourceAttr(g4Name, "name", "cn-50g-storage"),
+					resource.TestCheckResourceAttr(g4Name, "plan", "CLOUDNATIVE-4xCPU-8GB"),
+					resource.TestCheckResourceAttr(g4Name, "node_count", "1"),
+					resource.TestCheckResourceAttr(g4Name, "cloud_native_plan.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(g4Name, "cloud_native_plan.*", map[string]string{
+						"storage_size": "50",
+						"storage_tier": "standard",
+					}),
 				),
 			},
 		},

--- a/upcloud/testdata/upcloud_kubernetes/kubernetes_s2.tf
+++ b/upcloud/testdata/upcloud_kubernetes/kubernetes_s2.tf
@@ -87,6 +87,17 @@ resource "upcloud_kubernetes_node_group" "g3" {
   storage_encryption = "data-at-rest"
 }
 
+resource "upcloud_kubernetes_node_group" "g4" {
+  cluster    = upcloud_kubernetes_cluster.main.id
+  node_count = 1
+  name       = "cn-50g-storage"
+  plan       = "CLOUDNATIVE-4xCPU-8GB"
+  cloud_native_plan {
+    storage_size = 50
+    storage_tier = "standard"
+  }
+}
+
 data "upcloud_kubernetes_cluster" "main" {
   id = upcloud_kubernetes_cluster.main.id
 }


### PR DESCRIPTION
Changes:

- Allow Kubernetes node groups to define custom storage tier and size for Cloud Native server plans and GPU server plans.
- Update `upcloud-go-api` dependency to the latest version.
- Accepance test for a Cloud Native node group.

Both new plan types have their own configuration blocks `gpu_plan` and `cloud_native_plan`, aligning them with the `custom_plan` block and allowing plan-specific configuration in the future.