### PR TITLE
chore(objsto): clarify network type attribute in docs

### DIFF
--- a/docs/resources/managed_object_storage.md
+++ b/docs/resources/managed_object_storage.md
@@ -82,7 +82,7 @@ Required Attributes:
 
 - `family` (String) Network family. Currently only `IPv4` is supported.
 - `name` (String) Network name. Must be unique within the service.
-- `type` (String) Network type (`private` / `public`).
+- `type` (String) Network type (`private` or `public`).
 
 Optional Attributes:
 

--- a/internal/service/managedobjectstorage/managed_object_storage.go
+++ b/internal/service/managedobjectstorage/managed_object_storage.go
@@ -165,7 +165,7 @@ func (r *managedObjectStorageResource) Schema(_ context.Context, _ resource.Sche
 							},
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: "Network type.",
+							MarkdownDescription: "Network type (`private` or `public`).",
 							Required:            true,
 							Validators: []validator.String{
 								stringvalidator.OneOf(


### PR DESCRIPTION
For quicker/easier understanding.