### PR TITLE
fix(kubernetes): relax storage size validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - upcloud_managed_object_storage_user_policy: remove resource from state if resource has been deleted.
 - upcloud_managed_object_storage: do not wait for object storage instance to be deleted if delete request failed.
+- upcloud_kubernetes_node_group: relax `storage_size` validation to allow all positive integer smaller than 4096.
 
 ## [5.33.4] - 2026-02-04
 

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -244,7 +244,7 @@ func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.Schem
 								int64planmodifier.RequiresReplace(),
 							},
 							Validators: []validator.Int64{
-								int64validator.Between(25, 4096),
+								int64validator.Between(1, 4096),
 							},
 						},
 						"storage_tier": schema.StringAttribute{
@@ -284,7 +284,7 @@ func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.Schem
 								int64planmodifier.RequiresReplace(),
 							},
 							Validators: []validator.Int64{
-								int64validator.Between(25, 4096),
+								int64validator.Between(1, 4096),
 							},
 						},
 						"storage_tier": schema.StringAttribute{
@@ -324,7 +324,7 @@ func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.Schem
 								int64planmodifier.RequiresReplace(),
 							},
 							Validators: []validator.Int64{
-								int64validator.Between(25, 4096),
+								int64validator.Between(1, 4096),
 							},
 						},
 						"storage_tier": schema.StringAttribute{


### PR DESCRIPTION
API docs uses "positive integer" as the description for valid storage size values.