### PR TITLE
feat(kubernetes): add `name_prefix` field to node-group resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- upcloud_kubernetes_node_group: `name_prefix` field to help generating a unique name for the node group. This enables using `create_then_destroy` lifecycle strategy with the node-group resource.
+
 ### Fixed
 
 - upcloud_server: use 64-bit integers when parsing server host value from JSON response. No changes to the resource schema.

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -114,7 +114,7 @@ func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.Schem
 	nameReValidator := stringvalidator.RegexMatches(resourceNameRegexp, fmt.Sprintf("name should only contain lowercase alphanumeric characters and dashes (a-z, 0-9, -). Name should not start or end with a dash. Regular expresion used to check validation: %s", resourceNameRegexp))
 
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This resource represents a [Managed Kubernetes](https://upcloud.com/products/managed-kubernetes) cluster.",
+		MarkdownDescription: "This resource represents a node group in a [Managed Kubernetes](https://upcloud.com/products/managed-kubernetes) cluster. The node groups are used to define the worker nodes of the cluster.",
 		Attributes: map[string]schema.Attribute{
 			"anti_affinity": schema.BoolAttribute{
 				MarkdownDescription: "If set to true, nodes in this group will be placed on separate compute hosts. Please note that anti-affinity policy is considered 'best effort' and enabling it does not fully guarantee that the nodes will end up on different hardware.",

--- a/internal/service/kubernetes/node_group.go
+++ b/internal/service/kubernetes/node_group.go
@@ -73,6 +73,7 @@ type kubernetesNodeGroupModel struct {
 	ID                   types.String `tfsdk:"id"`
 	Labels               types.Map    `tfsdk:"labels"`
 	Name                 types.String `tfsdk:"name"`
+	NamePrefix           types.String `tfsdk:"name_prefix"`
 	NodeCount            types.Int64  `tfsdk:"node_count"`
 	Plan                 types.String `tfsdk:"plan"`
 	SSHKeys              types.Set    `tfsdk:"ssh_keys"`
@@ -110,6 +111,8 @@ type taintModel struct {
 }
 
 func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	nameReValidator := stringvalidator.RegexMatches(resourceNameRegexp, fmt.Sprintf("name should only contain lowercase alphanumeric characters and dashes (a-z, 0-9, -). Name should not start or end with a dash. Regular expresion used to check validation: %s", resourceNameRegexp))
+
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource represents a [Managed Kubernetes](https://upcloud.com/products/managed-kubernetes) cluster.",
 		Attributes: map[string]schema.Attribute{
@@ -140,14 +143,30 @@ func (r *kubernetesNodeGroupResource) Schema(_ context.Context, _ resource.Schem
 				mapplanmodifier.RequiresReplace(),
 			),
 			"name": schema.StringAttribute{
-				MarkdownDescription: "The name of the node group. Needs to be unique within a cluster.",
-				Required:            true,
+				MarkdownDescription: "The name of the node group. Needs to be unique within a cluster. Either `name` or `name_prefix` must be specified.",
+				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(resourceNameMaxLength),
-					stringvalidator.RegexMatches(resourceNameRegexp, fmt.Sprintf("name should only contain lowercase alphanumeric characters and dashes (a-z, 0-9, -). Name should not start or end with a dash. Regular expresion used to check validation: %s", resourceNameRegexp)),
+					nameReValidator,
+					stringvalidator.ExactlyOneOf(
+						path.MatchRoot("name_prefix"),
+					),
+				},
+			},
+			"name_prefix": schema.StringAttribute{
+				MarkdownDescription: "Like name, but appends a random string to the end to create a unique name beginning with the specified prefix. This enables using `create_before_destroy` lifecycle setting. Conflicts with `name`.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(resourceNameMaxLength - 6), // 6 characters are reserved for the random suffix
+					nameReValidator,
 				},
 			},
 			"node_count": schema.Int64Attribute{
@@ -469,12 +488,18 @@ func (r *kubernetesNodeGroupResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	name := data.Name.ValueString()
+	if name == "" && !data.NamePrefix.IsNull() {
+		name = utils.WithRandomSuffix(data.NamePrefix.ValueString())
+		data.Name = types.StringValue(name)
+	}
+
 	apiReq := request.CreateKubernetesNodeGroupRequest{
 		ClusterUUID: data.Cluster.ValueString(),
 		NodeGroup: request.KubernetesNodeGroup{
 			Count:                int(data.NodeCount.ValueInt64()),
 			Labels:               utils.LabelsMapToSlice(labels),
-			Name:                 data.Name.ValueString(),
+			Name:                 name,
 			Plan:                 data.Plan.ValueString(),
 			SSHKeys:              sshKeys,
 			Storage:              "",
@@ -713,6 +738,13 @@ func setNodeGroupValues(ctx context.Context, data *kubernetesNodeGroupModel, ng 
 	respDiagnostics.Append(diags...)
 
 	data.Name = types.StringValue(ng.Name)
+
+	namePrefixRe := regexp.MustCompile(fmt.Sprintf("^(.*)-[%s]{5}$", utils.RandomSuffixChars))
+	namePrefixMatch := namePrefixRe.FindStringSubmatch(ng.Name)
+	if isImport && len(namePrefixMatch) > 1 {
+		data.NamePrefix = types.StringValue(namePrefixMatch[1])
+	}
+
 	data.NodeCount = types.Int64Value(int64(ng.Count))
 	data.Plan = types.StringValue(ng.Plan)
 

--- a/internal/utils/test.go
+++ b/internal/utils/test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/config"
+	"github.com/UpCloudLtd/upcloud-go-api/credentials"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
 )
@@ -21,11 +22,13 @@ func ReadTestDataFile(t *testing.T, name string) string {
 func NewServiceWithCredentialsFromEnv(t *testing.T) *service.Service {
 	t.Helper()
 
-	cfg := config.Config{
-		Username: os.Getenv("UPCLOUD_USERNAME"),
-		Password: os.Getenv("UPCLOUD_PASSWORD"),
-		Token:    os.Getenv("UPCLOUD_TOKEN"),
+	creds, err := credentials.Parse(credentials.Credentials{})
+	if err != nil {
+		t.Skip("UpCloud credentials not set.")
+		return nil
 	}
+
+	cfg := config.NewFromCredentials(creds)
 	authFn, err := cfg.WithAuth()
 	if err != nil {
 		t.Skip("UpCloud credentials not set.")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -113,4 +114,19 @@ func JoinSchemas(dst map[string]*schema.Schema, s ...map[string]*schema.Schema) 
 		}
 	}
 	return dst
+}
+
+// From Kubernetes random suffixes.
+const RandomSuffixChars = "bcdfghjklmnpqrstvwxz2456789"
+
+func randomSuffix(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = RandomSuffixChars[rand.Intn(len(RandomSuffixChars))]
+	}
+	return string(b)
+}
+
+func WithRandomSuffix(input string) string {
+	return input + "-" + randomSuffix(5)
 }

--- a/upcloud/database/testdata/managed_database_s3.tf
+++ b/upcloud/database/testdata/managed_database_s3.tf
@@ -163,9 +163,9 @@ resource "upcloud_managed_database_valkey" "v1" {
 }
 
 resource "upcloud_managed_database_user" "db_user_1" {
-  service        = upcloud_managed_database_mysql.msql1.id
-  username       = "somename"
-  password       = "Superpass890"
+  service  = upcloud_managed_database_mysql.msql1.id
+  username = "somename"
+  password = "Superpass890"
 }
 
 resource "upcloud_managed_database_user" "db_user_2" {

--- a/upcloud/database/testdata/postgresql_import_minimal_properties_s1.tf
+++ b/upcloud/database/testdata/postgresql_import_minimal_properties_s1.tf
@@ -14,7 +14,7 @@ resource "upcloud_managed_database_postgresql" "props" {
   plan  = "1x1xCPU-2GB-25GB"
   zone  = var.zone
   properties {
-    version = 17
+    version     = 17
     service_log = false
   }
 }

--- a/upcloud/database/testdata/postgresql_import_minimal_properties_s2.tf
+++ b/upcloud/database/testdata/postgresql_import_minimal_properties_s2.tf
@@ -14,7 +14,7 @@ resource "upcloud_managed_database_postgresql" "props" {
   plan  = "1x1xCPU-2GB-25GB"
   zone  = var.zone
   properties {
-    version = 17
+    version     = 17
     service_log = false
     pglookout {
       max_failover_replication_time_lag = 60

--- a/upcloud/filestorage/testdata/file_storage_s3.tf
+++ b/upcloud/filestorage/testdata/file_storage_s3.tf
@@ -19,22 +19,22 @@ variable "zone" {
 }
 
 resource "upcloud_network" "this" {
-    name = "${var.prefix}${var.suffix}"
-    zone = var.zone
+  name = "${var.prefix}${var.suffix}"
+  zone = var.zone
 
-    ip_network {
-        address = "${var.cidr}"
-        dhcp    = true
-        family  = "IPv4"
-    }
+  ip_network {
+    address = var.cidr
+    dhcp    = true
+    family  = "IPv4"
+  }
 }
 resource "upcloud_file_storage" "this" {
-    name              = "${var.prefix}${var.suffix}-s3"
-    size              = 250
-    zone              = var.zone
-    configured_status = "started"
+  name              = "${var.prefix}${var.suffix}-s3"
+  size              = 250
+  zone              = var.zone
+  configured_status = "started"
 
-    labels = {
-        single = "onlyone"
-    }
+  labels = {
+    single = "onlyone"
+  }
 }

--- a/upcloud/filestorage/testdata/file_storage_s4.tf
+++ b/upcloud/filestorage/testdata/file_storage_s4.tf
@@ -24,30 +24,30 @@ variable "zone" {
 }
 
 resource "upcloud_network" "this" {
-    name = "${var.prefix}${var.suffix}"
-    zone = var.zone
+  name = "${var.prefix}${var.suffix}"
+  zone = var.zone
 
-    ip_network {
-        address = "${var.cidr}"
-        dhcp    = true
-        family  = "IPv4"
-    }
+  ip_network {
+    address = var.cidr
+    dhcp    = true
+    family  = "IPv4"
+  }
 }
 
 resource "upcloud_file_storage" "this" {
-    name              = "${var.prefix}${var.suffix}-s4"
-    size              = 250
-    zone              = var.zone
-    configured_status = "stopped"
+  name              = "${var.prefix}${var.suffix}-s4"
+  size              = 250
+  zone              = var.zone
+  configured_status = "stopped"
 
-    labels = {
-        single = "onlyone"
-    }
+  labels = {
+    single = "onlyone"
+  }
 
   network {
     family     = "IPv4"
     name       = "${var.prefix}${var.suffix}"
     uuid       = upcloud_network.this.id
-    ip_address = "${var.network-ip-addrs}"
+    ip_address = var.network-ip-addrs
   }
 }

--- a/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
+++ b/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
@@ -2,6 +2,8 @@ package kubernetestests
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/UpCloudLtd/terraform-provider-upcloud/internal/utils"
@@ -35,6 +37,15 @@ func getLatestVersions(t *testing.T) (string, string) {
 		return v[0], v[0]
 	}
 	return v[n-2], v[n-1]
+}
+
+func hasPrefix(prefix string) resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		if strings.HasPrefix(value, prefix) {
+			return nil
+		}
+		return fmt.Errorf("unexpected node group name to have prefix %q, got: %s", prefix, value)
+	}
 }
 
 func TestAccUpcloudKubernetes(t *testing.T) {
@@ -78,7 +89,8 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 					resource.TestCheckResourceAttr(cName, "name", "tf-acc-test-k8s-cluster"),
 					resource.TestCheckResourceAttr(cName, "version", s1Version),
 					resource.TestCheckResourceAttr(cName, "zone", "fi-hel2"),
-					resource.TestCheckResourceAttr(g1Name, "name", "small"),
+					resource.TestCheckResourceAttr(g1Name, "name_prefix", "small-"),
+					resource.TestCheckResourceAttrWith(g1Name, "name", hasPrefix("small-")),
 					resource.TestCheckResourceAttr(g2Name, "name", "medium"),
 					resource.TestCheckResourceAttr(g1Name, "anti_affinity", "true"),
 					resource.TestCheckResourceAttr(g2Name, "anti_affinity", "false"),

--- a/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
+++ b/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
@@ -89,7 +89,7 @@ func TestAccUpcloudKubernetes(t *testing.T) {
 					resource.TestCheckResourceAttr(cName, "name", "tf-acc-test-k8s-cluster"),
 					resource.TestCheckResourceAttr(cName, "version", s1Version),
 					resource.TestCheckResourceAttr(cName, "zone", "fi-hel2"),
-					resource.TestCheckResourceAttr(g1Name, "name_prefix", "small-"),
+					resource.TestCheckResourceAttr(g1Name, "name_prefix", "small"),
 					resource.TestCheckResourceAttrWith(g1Name, "name", hasPrefix("small-")),
 					resource.TestCheckResourceAttr(g2Name, "name", "medium"),
 					resource.TestCheckResourceAttr(g1Name, "anti_affinity", "true"),

--- a/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
+++ b/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
@@ -44,7 +44,7 @@ func hasPrefix(prefix string) resource.CheckResourceAttrWithFunc {
 		if strings.HasPrefix(value, prefix) {
 			return nil
 		}
-		return fmt.Errorf("unexpected node group name to have prefix %q, got: %s", prefix, value)
+		return fmt.Errorf("expected value to have prefix %q, got: %s", prefix, value)
 	}
 }
 

--- a/upcloud/kubernetes/testdata/kubernetes_e2e.tf
+++ b/upcloud/kubernetes/testdata/kubernetes_e2e.tf
@@ -42,10 +42,10 @@ resource "upcloud_network" "main" {
   router = upcloud_router.main.id
 
   ip_network {
-    address = var.network_cidr
-    dhcp    = true
+    address            = var.network_cidr
+    dhcp               = true
     dhcp_default_route = var.private_node_groups
-    family  = "IPv4"
+    family             = "IPv4"
   }
 }
 
@@ -155,7 +155,7 @@ resource "kubernetes_service_v1" "hello" {
     }
 
     port {
-      port = var.private_node_groups ? 443 : 80
+      port        = var.private_node_groups ? 443 : 80
       target_port = 80
     }
 
@@ -168,7 +168,7 @@ locals {
   has_external_ip = var.enable_kubernetes_resources ? contains(local.addresses.*.type, "ExternalIP") : false
   external_ip     = local.has_external_ip ? local.addresses[index(local.addresses.*.type, "ExternalIP")].address : "localhost"
   port            = var.enable_kubernetes_resources ? kubernetes_service_v1.hello[0].spec[0].port[0].node_port : 8080
-  lb_url = var.enable_kubernetes_resources && var.private_node_groups ? "https://${kubernetes_service_v1.hello[0].status[0].load_balancer[0].ingress[0].hostname}" : "localhost:8080"
+  lb_url          = var.enable_kubernetes_resources && var.private_node_groups ? "https://${kubernetes_service_v1.hello[0].status[0].load_balancer[0].ingress[0].hostname}" : "localhost:8080"
   service_url     = var.private_node_groups ? local.lb_url : "http://${local.external_ip}:${local.port != null ? local.port : 8080}/"
 }
 

--- a/upcloud/kubernetes/testdata/kubernetes_s1.tf
+++ b/upcloud/kubernetes/testdata/kubernetes_s1.tf
@@ -17,7 +17,7 @@ resource "upcloud_network" "main" {
   name = "${var.basename}net"
   zone = var.zone
   ip_network {
-    address = "172.23.34.0/24"
+    address = "172.23.35.0/24"
     dhcp    = true
     family  = "IPv4"
   }

--- a/upcloud/kubernetes/testdata/kubernetes_s1.tf
+++ b/upcloud/kubernetes/testdata/kubernetes_s1.tf
@@ -43,9 +43,9 @@ resource "upcloud_kubernetes_node_group" "g1" {
     env       = "dev"
     managedBy = "tf"
   }
-  name     = "small"
-  plan     = "2xCPU-4GB"
-  ssh_keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3fnjc8UrsYDNU8365mL3lnOPQJg18V42Lt8U/8Sm+r testt_test"]
+  name_prefix = "small"
+  plan        = "2xCPU-4GB"
+  ssh_keys    = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3fnjc8UrsYDNU8365mL3lnOPQJg18V42Lt8U/8Sm+r testt_test"]
   taint {
     effect = "NoExecute"
     key    = "taintKey"

--- a/upcloud/kubernetes/testdata/kubernetes_s2.tf
+++ b/upcloud/kubernetes/testdata/kubernetes_s2.tf
@@ -17,7 +17,7 @@ resource "upcloud_network" "main" {
   name = "${var.basename}net"
   zone = var.zone
   ip_network {
-    address = "172.23.34.0/24"
+    address = "172.23.35.0/24"
     dhcp    = true
     family  = "IPv4"
   }

--- a/upcloud/kubernetes/testdata/kubernetes_s2.tf
+++ b/upcloud/kubernetes/testdata/kubernetes_s2.tf
@@ -44,9 +44,9 @@ resource "upcloud_kubernetes_node_group" "g1" {
     env       = "dev"
     managedBy = "tf"
   }
-  name     = "small"
-  plan     = "2xCPU-4GB"
-  ssh_keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3fnjc8UrsYDNU8365mL3lnOPQJg18V42Lt8U/8Sm+r testt_test"]
+  name_prefix = "small"
+  plan        = "2xCPU-4GB"
+  ssh_keys    = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3fnjc8UrsYDNU8365mL3lnOPQJg18V42Lt8U/8Sm+r testt_test"]
   taint {
     effect = "NoExecute"
     key    = "taintKey"

--- a/upcloud/loadbalancer/testdata/loadbalancer_s2.tf
+++ b/upcloud/loadbalancer/testdata/loadbalancer_s2.tf
@@ -113,10 +113,10 @@ resource "upcloud_loadbalancer_backend" "lb_be_1" {
   # change: name lb-be-1-test to lb-be-1-test-1
   name = "lb-be-1-test-1"
   properties {
-    timeout_server          = 20
-    timeout_tunnel          = 4000
-    health_check_type       = "http"
-    outbound_proxy_protocol = "v1"
+    timeout_server             = 20
+    timeout_tunnel             = 4000
+    health_check_type          = "http"
+    outbound_proxy_protocol    = "v1"
     sticky_session_cookie_name = "Sticky-Session"
   }
 }

--- a/upcloud/loadbalancer/testdata/loadbalancer_s3.tf
+++ b/upcloud/loadbalancer/testdata/loadbalancer_s3.tf
@@ -80,10 +80,10 @@ resource "upcloud_loadbalancer_backend" "lb_be_1" {
   resolver_name = resource.upcloud_loadbalancer_resolver.lb_dns_1.name
   name          = "lb-be-1-test-1"
   properties {
-    timeout_server          = 20
-    timeout_tunnel          = 4000
-    health_check_type       = "http"
-    outbound_proxy_protocol = "v2"
+    timeout_server             = 20
+    timeout_tunnel             = 4000
+    health_check_type          = "http"
+    outbound_proxy_protocol    = "v2"
     sticky_session_cookie_name = "Session"
   }
 }

--- a/upcloud/loadbalancer/testdata/loadbalancer_s4.tf
+++ b/upcloud/loadbalancer/testdata/loadbalancer_s4.tf
@@ -74,10 +74,10 @@ resource "upcloud_loadbalancer_backend" "lb_be_1" {
   resolver_name = resource.upcloud_loadbalancer_resolver.lb_dns_1.name
   name          = "lb-be-1-test-1"
   properties {
-    timeout_server          = 20
-    timeout_tunnel          = 4000
-    health_check_type       = "http"
-    outbound_proxy_protocol = ""
+    timeout_server             = 20
+    timeout_tunnel             = 4000
+    health_check_type          = "http"
+    outbound_proxy_protocol    = ""
     sticky_session_cookie_name = ""
   }
 }

--- a/upcloud/loadbalancer/testdata/manual_certificate_bundle_s5.tf
+++ b/upcloud/loadbalancer/testdata/manual_certificate_bundle_s5.tf
@@ -102,5 +102,5 @@ resource "upcloud_loadbalancer_manual_certificate_bundle" "this" {
   certificate = local.certificate_clean
   # intermediates set to null
   intermediates = null
-  private_key = local.private_key
+  private_key   = local.private_key
 }

--- a/upcloud/managedobjectstorage/testdata/managed_object_storage_policy_version_s2.tf
+++ b/upcloud/managedobjectstorage/testdata/managed_object_storage_policy_version_s2.tf
@@ -15,9 +15,9 @@ resource "upcloud_managed_object_storage_policy" "this" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "ReadWrite"
-        Effect   = "Allow"
-        Action   = [
+        Sid    = "ReadWrite"
+        Effect = "Allow"
+        Action = [
           "s3:GetObject",
           "s3:PutObject"
         ]

--- a/upcloud/network/testdata/network_cfg1.tf
+++ b/upcloud/network/testdata/network_cfg1.tf
@@ -14,13 +14,13 @@ variable "router-name" {
 }
 
 variable "network-cidr" {
-  default    = "10.0.0.1/24"
-  type        = string
+  default = "10.0.0.1/24"
+  type    = string
 }
 
 variable "gateway-ip" {
-    default   = "10.0.0.1"
-  type        = string
+  default = "10.0.0.1"
+  type    = string
 }
 
 resource "upcloud_router" "r" {


### PR DESCRIPTION
This allows easily generating unique names for the node groups and enables using `create_then_destroy` lifecycle strategy with the node-group resource.