### PR TITLE
feat(file-storage): add encrypt field to upcloud_file_storage resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- upcloud_file_storage: add `encrypt` attribute.
+
 ## [5.37.0] - 2026-05-12
 
 ### Added

--- a/examples/resources/upcloud_file_storage/resource.tf
+++ b/examples/resources/upcloud_file_storage/resource.tf
@@ -16,6 +16,9 @@ resource "upcloud_file_storage" "example" {
   zone              = "fi-hel2"
   configured_status = "stopped"
 
+  # Encryption is set at creation and cannot be changed.
+  encrypt           = true
+
   labels = {
     environment = "staging"
     customer    = "example-customer"
@@ -27,15 +30,6 @@ resource "upcloud_file_storage" "example" {
     uuid       = upcloud_network.this.id
     ip_address = "172.16.8.11"
   }
-}
-
-# Encrypted file storage — encryption is set at creation and cannot be changed.
-resource "upcloud_file_storage" "encrypted" {
-  name              = "example-encrypted-file-storage"
-  size              = 250
-  zone              = "fi-hel2"
-  configured_status = "stopped"
-  encrypt           = true
 }
 
 resource "upcloud_file_storage_share" "example" {

--- a/examples/resources/upcloud_file_storage/resource.tf
+++ b/examples/resources/upcloud_file_storage/resource.tf
@@ -29,6 +29,15 @@ resource "upcloud_file_storage" "example" {
   }
 }
 
+# Encrypted file storage — encryption is set at creation and cannot be changed.
+resource "upcloud_file_storage" "encrypted" {
+  name              = "example-encrypted-file-storage"
+  size              = 250
+  zone              = "fi-hel2"
+  configured_status = "stopped"
+  encrypt           = true
+}
+
 resource "upcloud_file_storage_share" "example" {
   file_storage = upcloud_file_storage.example.id
   name         = "write-to-project"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.3
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1
-	github.com/UpCloudLtd/upcloud-go-api/v8 v8.36.1
+	github.com/UpCloudLtd/upcloud-go-api/v8 v8.37.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1 h1:eTfQsv58ufALOk9BZ7WbS/i7pMUD11RnYYpRPsz0LdI=
 github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1/go.mod h1:7OtVs2UqtfvjkC1HfE+Oud0MnbMv7qUWnbEgxnTAqts=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.36.1 h1:X9DUYl5IzwwGneDHzR+Akc1lNGgxYFGBtw8MtIhF8Vk=
-github.com/UpCloudLtd/upcloud-go-api/v8 v8.36.1/go.mod h1:sxG94uNhC31OQH+zK0RhZjVj+PdkhObsNAt5bvq2J8c=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.37.0 h1:ptUIKABcsDmopPWCFlVu2iIgzOzlanjA8QYmTLN//RQ=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.37.0/go.mod h1:sxG94uNhC31OQH+zK0RhZjVj+PdkhObsNAt5bvq2J8c=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/service/filestorage/file_storage.go
+++ b/internal/service/filestorage/file_storage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -54,6 +55,7 @@ func (r *fileStorageResource) Configure(_ context.Context, req resource.Configur
 
 type fileStorageModel struct {
 	ID               types.String `tfsdk:"id"`
+	Encrypt          types.Bool   `tfsdk:"encrypt"`
 	Name             types.String `tfsdk:"name"`
 	Size             types.Int64  `tfsdk:"size"`
 	Zone             types.String `tfsdk:"zone"`
@@ -121,6 +123,15 @@ func (r *fileStorageResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"labels": utils.LabelsAttribute("file storage"),
+			"encrypt": schema.BoolAttribute{
+				Description: "Sets if the file storage is encrypted at rest. Encryption can only be enabled at creation time and cannot be changed later.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"network": schema.SetNestedBlock{
@@ -163,6 +174,7 @@ func (r *fileStorageResource) Schema(_ context.Context, _ resource.SchemaRequest
 
 func setFileStorageModel(ctx context.Context, data *fileStorageModel, fileStorage *upcloud.FileStorage) diag.Diagnostics {
 	data.ID = types.StringValue(fileStorage.UUID)
+	data.Encrypt = types.BoolValue(fileStorage.Encrypted)
 	data.Name = types.StringValue(fileStorage.Name)
 	data.Size = types.Int64Value(int64(fileStorage.SizeGiB))
 	data.Zone = types.StringValue(fileStorage.Zone)
@@ -218,6 +230,7 @@ func (r *fileStorageResource) Create(ctx context.Context, req resource.CreateReq
 		SizeGiB:          int(data.Size.ValueInt64()),
 		Zone:             data.Zone.ValueString(),
 		ConfiguredStatus: upcloud.FileStorageConfiguredStatus(data.ConfiguredStatus.ValueString()),
+		Encrypted:        !data.Encrypt.IsNull() && !data.Encrypt.IsUnknown() && data.Encrypt.ValueBool(),
 		Labels:           utils.LabelsMapToSlice(labels),
 	}
 

--- a/internal/service/filestorage/file_storage.go
+++ b/internal/service/filestorage/file_storage.go
@@ -124,7 +124,7 @@ func (r *fileStorageResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"labels": utils.LabelsAttribute("file storage"),
 			"encrypt": schema.BoolAttribute{
-				Description: "Sets if the file storage is encrypted at rest. Encryption can only be enabled at creation time and cannot be changed later.",
+				Description: "Sets if the file storage is encrypted at rest. Encryption can only be enabled at creation time and cannot be changed later. Defaults to `false`.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
@@ -230,7 +230,7 @@ func (r *fileStorageResource) Create(ctx context.Context, req resource.CreateReq
 		SizeGiB:          int(data.Size.ValueInt64()),
 		Zone:             data.Zone.ValueString(),
 		ConfiguredStatus: upcloud.FileStorageConfiguredStatus(data.ConfiguredStatus.ValueString()),
-		Encrypted:        !data.Encrypt.IsNull() && !data.Encrypt.IsUnknown() && data.Encrypt.ValueBool(),
+		Encrypted:        data.Encrypt.ValueBool(),
 		Labels:           utils.LabelsMapToSlice(labels),
 	}
 

--- a/upcloud/filestorage/resource_upcloud_file_storage_test.go
+++ b/upcloud/filestorage/resource_upcloud_file_storage_test.go
@@ -128,6 +128,36 @@ func TestAccUpCloudFileStorage_basicLifecycle(t *testing.T) {
 	})
 }
 
+func TestAccUpCloudFileStorage_encrypted(t *testing.T) {
+	configEncrypted := utils.ReadTestDataFile(t, "testdata/file_storage_encrypted.tf")
+
+	prefix := "tf-acc-test-file-storage-"
+	suffix := acctest.RandString(4)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { upcloud.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: upcloud.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configEncrypted,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"suffix": config.StringVariable(suffix),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccFileStorageExists("upcloud_file_storage.encrypted"),
+					resource.TestCheckResourceAttr("upcloud_file_storage.encrypted", "encrypt", "true"),
+				),
+			},
+			{
+				ResourceName:      "upcloud_file_storage.encrypted",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccFileStorageExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[resourceName]

--- a/upcloud/filestorage/testdata/file_storage_encrypted.tf
+++ b/upcloud/filestorage/testdata/file_storage_encrypted.tf
@@ -1,0 +1,17 @@
+variable "prefix" {
+  default = "tf-acc-test-file-storage-"
+  type    = string
+}
+
+variable "suffix" {
+  default = "suffix"
+  type    = string
+}
+
+resource "upcloud_file_storage" "encrypted" {
+  name              = "${var.prefix}${var.suffix}-enc"
+  size              = 250
+  zone              = "fi-hel2"
+  configured_status = "stopped"
+  encrypt           = true
+}

--- a/upcloud/filestorage/testdata/file_storage_encrypted.tf
+++ b/upcloud/filestorage/testdata/file_storage_encrypted.tf
@@ -3,13 +3,8 @@ variable "prefix" {
   type    = string
 }
 
-variable "suffix" {
-  default = "suffix"
-  type    = string
-}
-
 resource "upcloud_file_storage" "encrypted" {
-  name              = "${var.prefix}${var.suffix}-enc"
+  name              = "${var.prefix}-encrypted"
   size              = 250
   zone              = "fi-hel2"
   configured_status = "stopped"


### PR DESCRIPTION
Exposes the UpCloud File Storage encryption-at-rest setting as an optional computed encrypt attribute. The field uses RequiresReplace since encryption can only be set at creation time and is immutable thereafter.
Depends on upcloud-go-api adding Encrypted to FileStorage and CreateFileStorageRequest. Resolves issue #994.

I have been able to test the working of it with the provider build locally.
Let me know if there is anything missing!