### PR TITLE
fix(gateway): document that plan is required and list valid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- upcloud_gateway: the API now requires a plan to be specified when creating a gateway, so set `development` as a default value for `plan` field to avoid breaking existing configurations.
+
 ## [5.41.0] - 2026-07-13
 
 ### Added

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -67,7 +67,7 @@ resource "upcloud_gateway" "this" {
 
 - `configured_status` (String) The service configured status indicates the service's current intended status. Managed by the customer.
 - `labels` (Map of String) User defined key-value pairs to classify the network gateway.
-- `plan` (String) Gateway pricing plan. Required by the UpCloud API when creating a gateway. Valid values: essentials, development, standard, production, advanced.
+- `plan` (String) Gateway pricing plan, defaults to `development`. You can list available plans with `upctl gateway plans`.
 
 ### Blocks
 
@@ -77,7 +77,7 @@ resource "upcloud_gateway" "this" {
 ### Read-Only
 
 - `addresses` (Set of Object, Deprecated) IP addresses assigned to the gateway. (see [below for nested schema](#nestedatt--addresses))
-- `connections` (List of String) Names of connections attached to the gateway. Note that this field can have outdated information as connections are created by a separate resource. To make sure that you have the most recent data run 'terrafrom refresh'.
+- `connections` (List of String) Names of connections attached to the gateway. Note that this field can have outdated information as connections are created by a separate resource. To make sure that you have the most recent data run 'terraform refresh'.
 - `id` (String) The ID of this resource.
 - `operational_state` (String) The service operational state indicates the service's current operational, effective state. Managed by the system.
 

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -42,6 +42,7 @@ resource "upcloud_gateway" "this" {
   name     = "gateway-example-gw"
   zone     = "pl-waw1"
   features = ["nat"]
+  plan     = "development"
 
   router {
     id = upcloud_router.this.id
@@ -66,7 +67,7 @@ resource "upcloud_gateway" "this" {
 
 - `configured_status` (String) The service configured status indicates the service's current intended status. Managed by the customer.
 - `labels` (Map of String) User defined key-value pairs to classify the network gateway.
-- `plan` (String) Gateway pricing plan.
+- `plan` (String) Gateway pricing plan. Required by the UpCloud API when creating a gateway. Valid values: essentials, development, standard, production, advanced.
 
 ### Blocks
 

--- a/examples/resources/upcloud_gateway/resource.tf
+++ b/examples/resources/upcloud_gateway/resource.tf
@@ -27,6 +27,7 @@ resource "upcloud_gateway" "this" {
   name     = "gateway-example-gw"
   zone     = "pl-waw1"
   features = ["nat"]
+  plan     = "development"
 
   router {
     id = upcloud_router.this.id

--- a/internal/service/gateway/gateway.go
+++ b/internal/service/gateway/gateway.go
@@ -97,8 +97,8 @@ func ResourceGateway() *schema.Resource {
 			},
 			"plan": {
 				Description: planDescription,
-				Computed:    true,
-				Optional:    true,
+				// Computed:    true,
+				Optional: true,
 				// Plan is now required by the API, so set the default value here to avoid breaking existing configurations.
 				Default: "development",
 				Type:    schema.TypeString,

--- a/internal/service/gateway/gateway.go
+++ b/internal/service/gateway/gateway.go
@@ -26,8 +26,8 @@ const (
 	configuredStatusDescription = "The service configured status indicates the service's current intended status. Managed by the customer."
 	operationalStateDescription = "The service operational state indicates the service's current operational, effective state. Managed by the system."
 	addressesDescription        = "IP addresses assigned to the gateway."
-	planDescription             = "Gateway pricing plan. Required by the UpCloud API when creating a gateway. Valid values: essentials, development, standard, production, advanced."
-	connectionsDescription      = "Names of connections attached to the gateway. Note that this field can have outdated information as connections are created by a separate resource. To make sure that you have the most recent data run 'terrafrom refresh'."
+	planDescription             = "Gateway pricing plan, defaults to `development`. You can list available plans with `upctl gateway plans`."
+	connectionsDescription      = "Names of connections attached to the gateway. Note that this field can have outdated information as connections are created by a separate resource. To make sure that you have the most recent data run 'terraform refresh'."
 
 	cleanupWaitTimeSeconds = 15
 )
@@ -99,7 +99,9 @@ func ResourceGateway() *schema.Resource {
 				Description: planDescription,
 				Computed:    true,
 				Optional:    true,
-				Type:        schema.TypeString,
+				// Plan is now required by the API, so set the default value here to avoid breaking existing configurations.
+				Default: "development",
+				Type:    schema.TypeString,
 			},
 			"address": {
 				Description: addressesDescription,

--- a/internal/service/gateway/gateway.go
+++ b/internal/service/gateway/gateway.go
@@ -26,7 +26,7 @@ const (
 	configuredStatusDescription = "The service configured status indicates the service's current intended status. Managed by the customer."
 	operationalStateDescription = "The service operational state indicates the service's current operational, effective state. Managed by the system."
 	addressesDescription        = "IP addresses assigned to the gateway."
-	planDescription             = "Gateway pricing plan."
+	planDescription             = "Gateway pricing plan. Required by the UpCloud API when creating a gateway. Valid values: essentials, development, standard, production, advanced."
 	connectionsDescription      = "Names of connections attached to the gateway. Note that this field can have outdated information as connections are created by a separate resource. To make sure that you have the most recent data run 'terrafrom refresh'."
 
 	cleanupWaitTimeSeconds = 15


### PR DESCRIPTION
Relates to #1032.

 The UpCloud API rejects gateway creation without `plan`, but the schema description and the Example Usage don't mention it. This PR:

  - adds the valid plan values and the API requirement to the `plan` attribute description
  - adds `plan` to the example so it works when copy-pasted
  - regenerates the docs (`make docs`)

  Deliberately does not change the schema (required vs. default is left to #1032).