### PR TITLE
chore: remove tofu specific empty plan logic

### DIFF
--- a/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
+++ b/upcloud/kubernetes/resource_upcloud_kubernetes_test.go
@@ -287,8 +287,6 @@ func testEndToEndKubernetes(t *testing.T, cidr string, privateNodeGroups bool) {
 					"private_node_groups": config.BoolVariable(privateNodeGroups),
 					"network_cidr":        config.StringVariable(cidr),
 				},
-				// OpenTofu adds open action for the ephemeral resource which causes the plan to be non-empty.
-				ExpectNonEmptyPlan: upcloud.UsingOpenTofu(),
 			},
 			{
 				Config: testdata,
@@ -306,8 +304,6 @@ func testEndToEndKubernetes(t *testing.T, cidr string, privateNodeGroups bool) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.http.hello.0", "status_code", "200"),
 				),
-				// OpenTofu adds open action for the ephemeral resource which causes the plan to be non-empty.
-				ExpectNonEmptyPlan: upcloud.UsingOpenTofu(),
 			},
 		},
 	})

--- a/upcloud/test_helpers.go
+++ b/upcloud/test_helpers.go
@@ -71,10 +71,6 @@ func CheckStringDoesNotChange(name, key string, expected *string) resource.TestC
 	}
 }
 
-func UsingOpenTofu() bool {
-	return strings.HasSuffix(os.Getenv("TF_ACC_TERRAFORM_PATH"), "tofu")
-}
-
 func GenerateSSHKeyPair(keyDir string) error {
 	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	if err != nil {


### PR DESCRIPTION
OpenTofu does not include open actions for ephemeral resources in plan anymore (since v1.12.0), so we should expect empty plan also when testing with OpenTofu.